### PR TITLE
Clearing mocks between tests

### DIFF
--- a/test/controllers/company.number.controller.unit.ts
+++ b/test/controllers/company.number.controller.unit.ts
@@ -5,6 +5,13 @@ import app from "../../src/app";
 const EXPECTED_LOCATION = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber=%7BcompanyNumber%7D";
 
 describe("company number controller tests", () => {
+
+  beforeEach(() => {
+    mocks.mockAuthenticationMiddleware.mockClear();
+    mocks.mockServiceAvailabilityMiddleware.mockClear();
+    mocks.mockSessionMiddleware.mockClear();
+  });
+
   it("should return company number page", async () => {
     const response = await request(app)
       .get("/confirmation-statement/company-number");

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -1,5 +1,3 @@
-jest.mock("ioredis");
-
 import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
@@ -7,6 +5,12 @@ import { CONFIRM_COMPANY_PATH } from "../../src/types/page.urls";
 
 describe("Confirm company controller tests", () => {
   const PAGE_HEADING = "Confirm this is the correct company";
+
+  beforeEach(() => {
+    mocks.mockAuthenticationMiddleware.mockClear();
+    mocks.mockServiceAvailabilityMiddleware.mockClear();
+    mocks.mockSessionMiddleware.mockClear();
+  });
 
   it("Should navigate to confirm company page", async () => {
     const response = await request(app).get(CONFIRM_COMPANY_PATH);

--- a/test/controllers/error.controller.unit.ts
+++ b/test/controllers/error.controller.unit.ts
@@ -6,6 +6,13 @@ const EXPECTED_TEXT = "Page not found - File a confirmation statement";
 const INCORRECT_URL = "/confirmation-statement/company-numberr";
 
 describe("error controller test", () => {
+
+  beforeEach(() => {
+    mocks.mockAuthenticationMiddleware.mockClear();
+    mocks.mockServiceAvailabilityMiddleware.mockClear();
+    mocks.mockSessionMiddleware.mockClear();
+  });
+
   it("should return page not found screen if page url is not recognised", async () => {
     const response = await request(app)
       .get(INCORRECT_URL);

--- a/test/controllers/start.controller.unit.ts
+++ b/test/controllers/start.controller.unit.ts
@@ -5,6 +5,13 @@ import app from "../../src/app";
 const EXPECTED_TEXT = "File a confirmation statement";
 
 describe("start controller tests", () => {
+
+  beforeEach(() => {
+    middlewareMocks.mockAuthenticationMiddleware.mockClear();
+    middlewareMocks.mockServiceAvailabilityMiddleware.mockClear();
+    middlewareMocks.mockSessionMiddleware.mockClear();
+  });
+
   it("should return start page", async () => {
     const response = await request(app)
       .get("/confirmation-statement");

--- a/test/middleware/service.availability.middleware.unit.ts
+++ b/test/middleware/service.availability.middleware.unit.ts
@@ -9,6 +9,10 @@ const mockIsActiveFeature = isActiveFeature as jest.Mock;
 
 describe("service availability middleware tests", () => {
 
+  beforeEach(() => {
+    mockIsActiveFeature.mockClear();
+  });
+
   it("should return service offline page", async () => {
     mockIsActiveFeature.mockReturnValueOnce(true);
     const response = await request(app).get("/confirmation-statement");


### PR DESCRIPTION
Noticed that we hadn't been clearing the mocks between tests which could cause issues in the future so added beforeEach blocks to clear them down.