### PR TITLE
NCS-249 Fix for date formatter handling falsey strings and removing un…

### DIFF
--- a/src/services/company.profile.service.ts
+++ b/src/services/company.profile.service.ts
@@ -1,5 +1,5 @@
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { CompanyProfile, ConfirmationStatement } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { CHS_API_KEY } from "../utils/properties";
 import logger from "../utils/logger";
 import { lookupCompanyStatus, lookupCompanyType } from "../utils/api.enumerations";
@@ -23,7 +23,7 @@ export const getCompanyProfile = async (companyNumber: string): Promise<CompanyP
     return logAndThrowError(new Error (`Company Profile API returned no resource for company number ${companyNumber}`));
   }
 
-  logger.debug(`Received company profile ${sdkResponse}`);
+  logger.debug(`Received company profile ${JSON.stringify(sdkResponse)}`);
 
   return transform(sdkResponse.resource);
 };
@@ -37,9 +37,11 @@ const transform = (companyProfile: CompanyProfile): CompanyProfile => {
   companyProfile.type = lookupCompanyType(companyProfile.type);
   companyProfile.companyStatus = lookupCompanyStatus(companyProfile.companyStatus);
   companyProfile.dateOfCreation = readableFormat(companyProfile.dateOfCreation);
-  companyProfile.confirmationStatement.nextDue = readableFormat(companyProfile.confirmationStatement.nextDue);
-  companyProfile.confirmationStatement.lastMadeUpTo = companyProfile.confirmationStatement.lastMadeUpTo ? readableFormat(companyProfile.confirmationStatement.lastMadeUpTo) : "";
-  companyProfile.confirmationStatement.nextMadeUpTo = companyProfile.confirmationStatement.nextMadeUpTo ? readableFormat(companyProfile.confirmationStatement.nextMadeUpTo) : "";
 
+  if (companyProfile.confirmationStatement) {
+    const confirmationStatement: ConfirmationStatement = companyProfile.confirmationStatement;
+    confirmationStatement.nextDue = readableFormat(confirmationStatement.nextDue);
+    confirmationStatement.lastMadeUpTo = confirmationStatement.lastMadeUpTo ? readableFormat(confirmationStatement.lastMadeUpTo) : "";
+  }
   return companyProfile;
 };

--- a/src/utils/date.formatter.ts
+++ b/src/utils/date.formatter.ts
@@ -2,6 +2,9 @@ import logger from "./logger";
 import { DateTime } from "luxon";
 
 export const readableFormat = (dateToConvert: string): string => {
+  if (!dateToConvert) {
+    return "";
+  }
   const jsDate = new Date(dateToConvert);
   const dateTime = DateTime.fromJSDate(jsDate);
   const convertedDate = dateTime.toFormat("dd MMMM yyyy");

--- a/test/services/company.profile.service.unit.ts
+++ b/test/services/company.profile.service.unit.ts
@@ -53,7 +53,6 @@ describe("Company profile service test", () => {
     expect(mockReadableFormat.mock.calls[0][0]).toEqual(validSDKResource?.resource?.dateOfCreation);
     expect(mockReadableFormat.mock.calls[1][0]).toEqual(validSDKResource?.resource?.confirmationStatement.nextDue);
     expect(mockReadableFormat.mock.calls[2][0]).toEqual(validSDKResource?.resource?.confirmationStatement.lastMadeUpTo);
-    expect(mockReadableFormat.mock.calls[3][0]).toEqual(validSDKResource?.resource?.confirmationStatement.nextMadeUpTo);
   });
 
   it("Should return empty strings for undefined dates", async () => {
@@ -61,13 +60,11 @@ describe("Company profile service test", () => {
     const clonedSDKResource: Resource<CompanyProfile> = JSON.parse(JSON.stringify(validSDKResource));
     if (clonedSDKResource.resource) {
       clonedSDKResource.resource.confirmationStatement.lastMadeUpTo = undefined;
-      clonedSDKResource.resource.confirmationStatement.nextMadeUpTo = undefined;
     }
     mockGetCompanyProfile.mockResolvedValueOnce(clonedSDKResource);
     const result: CompanyProfile = await getCompanyProfile(COMPANY_NUMBER);
 
     expect(result.confirmationStatement.lastMadeUpTo).toEqual("");
-    expect(result.confirmationStatement.nextMadeUpTo).toEqual("");
   });
 
   it("Should convert company status into readable format", async () => {

--- a/test/services/company.profile.service.unit.ts
+++ b/test/services/company.profile.service.unit.ts
@@ -4,7 +4,7 @@ jest.mock("../../src/utils/date.formatter");
 jest.mock("../../src/utils/api.enumerations");
 
 import { getCompanyProfile } from "../../src/services/company.profile.service";
-import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { CompanyProfile, ConfirmationStatement } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
 import logger from "../../src/utils/logger";
 import { validSDKResource } from "../mocks/company.profile.mock";
@@ -65,6 +65,18 @@ describe("Company profile service test", () => {
     const result: CompanyProfile = await getCompanyProfile(COMPANY_NUMBER);
 
     expect(result.confirmationStatement.lastMadeUpTo).toEqual("");
+  });
+
+  it("Should not try to convert confirmation statement dates if confirmation statement undefined", async () => {
+    const clonedSDKResource: Resource<CompanyProfile> = JSON.parse(JSON.stringify(validSDKResource));
+    if (clonedSDKResource.resource) {
+      clonedSDKResource.resource.confirmationStatement = undefined as unknown as ConfirmationStatement;
+    }
+    mockGetCompanyProfile.mockResolvedValueOnce(clonedSDKResource);
+    await getCompanyProfile(COMPANY_NUMBER);
+
+    expect(mockReadableFormat.mock.calls[0][0]).toEqual(validSDKResource?.resource?.dateOfCreation);
+    expect(mockReadableFormat).toBeCalledTimes(1);
   });
 
   it("Should convert company status into readable format", async () => {

--- a/test/utils/date.formatter.unit.ts
+++ b/test/utils/date.formatter.unit.ts
@@ -19,14 +19,35 @@ describe("Date formatter tests", () => {
     expect(date).toEqual("18 March 2019");
   });
 
+  it("Should return empty string if date is undefined", () => {
+    const input = undefined as unknown as string;
+    const date = readableFormat(input);
+
+    expect(date).toEqual("");
+  });
+
+  it("Should return empty string if date is null", () => {
+    const input = null as unknown as string;
+    const date = readableFormat(input);
+
+    expect(date).toEqual("");
+  });
+
+  it("Should return empty string if date is empty string", () => {
+    const input = "";
+    const date = readableFormat(input);
+
+    expect(date).toEqual("");
+  });
+
   it("Should log and throw an error", () => {
-    const nullString = "";
+    const badDate = "12345/44/44";
 
     try {
-      readableFormat(nullString);
+      readableFormat(badDate);
       fail();
     } catch (e) {
-      expect(e.message).toContain(nullString);
+      expect(e.message).toContain(badDate);
       expect(logger.error).toHaveBeenCalledWith(expect.stringContaining(e.message));
     }
   });


### PR DESCRIPTION
…necessary date conversion on company profile

Changed date formatter to return empty string if input string is falsey

Added a falsey check to the confirmation statement section of the SDk response to only convert the conf statement dates if conf statement is present

The nextMadeUpTo date isn't used by the company profile screen so i've not converted it.