### PR TITLE
NCS-192 Upgrading private-api-sdk-node version to fix Docker startup i…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,16 +1385,6 @@
         "picomatch": "^2.0.4"
       }
     },
-    "api-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#1bb3614e427588c29fb7233f32365a1503f992cc",
-      "from": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#0.2.8",
-      "requires": {
-        "camelcase-keys": "~6.2.2",
-        "request": "~2.88.0",
-        "request-promise-native": "~1.0.8",
-        "snakecase-keys": "~3.2.0"
-      }
-    },
     "archive-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
@@ -5562,10 +5552,10 @@
       }
     },
     "private-api-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#87e7d50eedda62d1a4ffa48c9f80161432023373",
-      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.10",
+      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#966d9dc53021f5be1227fc98b276bc20217b0400",
+      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.12",
       "requires": {
-        "api-sdk-node": "git+ssh://git@github.com/companieshouse/api-sdk-node.git#0.2.8",
+        "@companieshouse/api-sdk-node": "^1.0.26",
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.0",
         "request-promise-native": "~1.0.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@companieshouse/node-session-handler": "^4.1.6",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/web-security-node": "^1.0.2",
-    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.10",
     "cookie-parser": "^1.4.5",
     "express": "^4.17.1",
     "govuk-frontend": "^3.11.0",
@@ -37,6 +36,7 @@
     "js-yaml": "^3.14.1",
     "luxon": "^1.26.0",
     "nunjucks": "^3.2.3",
+    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.12",
     "yargs": "^15.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
…ssues

Upgrading private-api-sdk-node version to fix Docker startup issues due to private-api using an old api-sdk-node