### PR TITLE
Unit test coverage increase and small change needed to api service to…

### DIFF
--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -8,12 +8,9 @@ import { INTERNAL_API_URL } from "../../utils/properties";
 import { logAndThrowError } from "../../utils/logger";
 
 export const createOAuthApiClient = (session: Session): PrivateApiClient => {
-  const signInInfo = session.data?.[SessionKey.SignInInfo];
-  if (signInInfo) {
-    const oAuth: string = signInInfo?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken] as string;
-    if (oAuth) {
-      return createPrivateApiClient(undefined, oAuth, INTERNAL_API_URL);
-    }
+  const oAuth = session.data?.[SessionKey.SignInInfo]?.[SignInInfoKeys.AccessToken]?.[AccessTokenKeys.AccessToken];
+  if (oAuth) {
+    return createPrivateApiClient(undefined, oAuth, INTERNAL_API_URL);
   }
   return logAndThrowError(new Error ("Error getting session keys for creating api client"));
 };

--- a/test/services/api/api.service.unit.ts
+++ b/test/services/api/api.service.unit.ts
@@ -13,7 +13,7 @@ describe ("Test node session handler authorization for private sdk", () => {
 
   it("should throw error when no data is present", () => {
     try {
-      createOAuthApiClient(getEmptySessionRequest());
+      createOAuthApiClient({} as Session);
       fail();
     } catch (error) {
       expect(error.message).toBe(ERROR_MESSSAGE);


### PR DESCRIPTION
… increase the coverage

Sonar was complaining that signInInfo? hadn't been tested when undefined but we couldn't do that due to the 'if' check before it
if (signInInfo) {
    const oAuth: string = signInInfo?.[SignInInfoK.....

turns out we can just use the ? to check if signInInfo is present, if not the ? will return undefined so we can just chain the calls to get oAuth.