### PR TITLE
Setting package.json type field to load modules as ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Web front end for Confirmation Statement service",
   "main": "app.ts",
+  "type": "module",
   "scripts": {
     "start": "node dist/bin/www.js",
     "build": "tsc && cp -r views dist/",


### PR DESCRIPTION
We should be explicit about the type of modules we import, ES modules are what we are using (as apposed to CommonJS with require) so setting that in the package.json . See https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_package_json_type_field for info.