### PR TITLE
Making logger a named export to keep logger naming consistent

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,7 +9,7 @@ import { authenticationMiddleware } from "./middleware/authentication.middleware
 import { sessionMiddleware } from "./middleware/session.middleware";
 
 import cookieParser from "cookie-parser";
-import logger from "./utils/logger";
+import { logger } from "./utils/logger";
 
 const app = express();
 

--- a/src/controllers/error.controller.ts
+++ b/src/controllers/error.controller.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import logger from "../utils/logger";
+import { logger } from "../utils/logger";
 import { Templates } from "../types/template.paths";
 
 const pageNotFound = (req: Request, res: Response) => {

--- a/src/services/company.profile.service.ts
+++ b/src/services/company.profile.service.ts
@@ -1,7 +1,7 @@
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
 import { CompanyProfile, ConfirmationStatement } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { CHS_API_KEY } from "../utils/properties";
-import logger from "../utils/logger";
+import { logger } from "../utils/logger";
 import { lookupCompanyStatus, lookupCompanyType } from "../utils/api.enumerations";
 import { readableFormat } from "../utils/date.formatter";
 

--- a/src/utils/date.formatter.ts
+++ b/src/utils/date.formatter.ts
@@ -1,4 +1,4 @@
-import logger from "./logger";
+import { logger } from "./logger";
 import { DateTime } from "luxon";
 
 export const readableFormat = (dateToConvert: string): string => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,9 +1,7 @@
 import { createLogger } from "@companieshouse/structured-logging-node";
 import ApplicationLogger from "@companieshouse/structured-logging-node/lib/ApplicationLogger";
 
-const logger: ApplicationLogger = createLogger("Confirmation Statement Web");
-
-export default logger;
+export const logger: ApplicationLogger = createLogger("Confirmation Statement Web");
 
 export const logAndThrowError = (error: Error) => {
   logger.error(`${error.message} - ${error.stack}`);

--- a/test/controllers/error.controller.unit.ts
+++ b/test/controllers/error.controller.unit.ts
@@ -5,7 +5,7 @@ import request from "supertest";
 import app from "../../src/app";
 import { NextFunction } from "express";
 import { CONFIRM_COMPANY_PATH } from "../../src/types/page.urls";
-import logger from "../../src/utils/logger";
+import { logger } from "../../src/utils/logger";
 
 const mockLoggerErrorRequest = logger.errorRequest as jest.Mock;
 

--- a/test/services/company.profile.service.unit.ts
+++ b/test/services/company.profile.service.unit.ts
@@ -6,7 +6,7 @@ jest.mock("../../src/utils/api.enumerations");
 import { getCompanyProfile } from "../../src/services/company.profile.service";
 import { CompanyProfile, ConfirmationStatement } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
-import logger from "../../src/utils/logger";
+import { logger } from "../../src/utils/logger";
 import { validSDKResource } from "../mocks/company.profile.mock";
 import { readableFormat } from "../../src/utils/date.formatter";
 import { lookupCompanyStatus, lookupCompanyType } from "../../src/utils/api.enumerations";

--- a/test/utils/date.formatter.unit.ts
+++ b/test/utils/date.formatter.unit.ts
@@ -1,7 +1,7 @@
 jest.mock("../../src/utils/logger");
 
 import { readableFormat } from "../../src/utils/date.formatter";
-import logger from "../../src/utils/logger";
+import { logger } from "../../src/utils/logger";
 
 describe("Date formatter tests", () => {
 


### PR DESCRIPTION
To keep naming of the logger consistent I've changed it to be a named export instead of default.