### PR TITLE
Adding test for properties.ts

### DIFF
--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -4,7 +4,7 @@
  * thrown.
  */
 
-const getEnvironmentVariable = (key: string, defaultValue?: any): string => {
+const getEnvironmentVariable = (key: string, defaultValue?: string): string => {
   const isMandatory = !defaultValue;
   const value: string = process.env[key] || "";
 
@@ -30,3 +30,7 @@ export const CHS_API_KEY = getEnvironmentVariable("CHS_API_KEY");
 export const INTERNAL_API_URL = getEnvironmentVariable("INTERNAL_API_URL");
 
 export const FEATURE_FLAG_PRIVATE_SDK_12052021 = getEnvironmentVariable("FEATURE_FLAG_PRIVATE_SDK_12052021");
+
+export const testingOnly = {
+  getEnvironmentVariable
+};

--- a/test/utils/properties.unit.ts
+++ b/test/utils/properties.unit.ts
@@ -1,0 +1,29 @@
+import { testingOnly } from "../../src/utils/properties";
+const { getEnvironmentVariable } = testingOnly;
+
+describe("Properties tests", () => {
+
+  describe("getEnvironmentVariable tests", () => {
+
+    it("Should return environment variable", () => {
+      const varName = "ENV_VAR_TEST";
+      const varVal = "hello";
+      process.env[varName] = varVal;
+
+      const returned: string = getEnvironmentVariable(varName);
+
+      expect(returned).toEqual<string>(varVal);
+    });
+
+    it("Should throw error if environment variable not found", () => {
+      expect(() => getEnvironmentVariable("missing"))
+        .toThrow('Please set the environment variable "missing"');
+    });
+
+    it("Should return default value if environment variable not found", () => {
+      const defaultValue = "55";
+      const envVar: string = getEnvironmentVariable("missing", defaultValue);
+      expect(envVar).toEqual<string>(defaultValue);
+    });
+  });
+});


### PR DESCRIPTION
getEnvironmentVariable is not exported and I didn't want to export it as it would break the way the module is used. So I found a good suggestion on stack overflow - https://stackoverflow.com/a/54116079 - to export an object that wraps the function and name it so it is obviously for testing use only.

During testing I found that the defaultValue doesn't get converted to string when using the 'as string' in the final line of the function and when called with an int as defaultValue, it returned the int instead of a string version of it. The function has a return type of string and env vars are supposed to be strings, so I've changed the defaultValue param from any to string.