### PR TITLE
Fix to make tests run on nvm v12 and higher

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   roots: [
     "<rootDir>"
   ],


### PR DESCRIPTION
Tests failed to run on nvm 12 and higher.
Fixed by using the newer style 'export' in jest.config and renamed it from .js to .ts