### PR TITLE
Fix tests for nvm v14

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   roots: [
     "<rootDir>"
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "Web front end for Confirmation Statement service",
   "main": "app.ts",
-  "type": "module",
   "scripts": {
     "start": "node dist/bin/www.js",
     "build": "tsc && cp -r views dist/",


### PR DESCRIPTION
reverting jest.config changes and removing the "types": "modules" from package.json to allow tests to run on all versions of nvm