### PR TITLE
Ncs 267 company types display bug

### DIFF
--- a/src/utils/api.enumerations.ts
+++ b/src/utils/api.enumerations.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as yaml from "js-yaml";
+import { editCompanyTypeDisplay } from "./company.type.display.procressor";
 
 interface ApiEnumerationsConstants {
   [propName: string]: any
@@ -11,7 +12,8 @@ const apiConstants: ApiEnumerationsConstants = yaml.load(apiConstantsFile) as Ap
 export const lookupCompanyType = (companyTypeKey: string): string => {
   // we actually use the 'company_summary' values from the yaml file to
   //  display the company type (following the ch.gov.uk templates)
-  return apiConstants.company_summary[companyTypeKey] || companyTypeKey;
+  const displayValue: string = apiConstants.company_summary[companyTypeKey] || companyTypeKey;
+  return editCompanyTypeDisplay(companyTypeKey, displayValue);
 };
 
 export const lookupCompanyStatus = (companyStatusKey: string): string => {

--- a/src/utils/company.type.display.procressor.ts
+++ b/src/utils/company.type.display.procressor.ts
@@ -5,7 +5,7 @@ const multipleSpaces = /[\s]+/g;
 
 export const editCompanyTypeDisplay = (companyTypeKey: string, displayValue: string): string => {
   let editedDisplayValue: string = removeNonAlphanumericChars(displayValue);
-  editedDisplayValue = removedUnrequiredWords(companyTypeKey, editedDisplayValue, displayValue);
+  editedDisplayValue = removeUnrequiredWords(companyTypeKey, editedDisplayValue, displayValue);
   if (editedDisplayValue.length === 0) {
     return displayValue;
   }
@@ -20,7 +20,7 @@ const ensureTitleCase = (editedDisplayValue: string): string => {
   return editedDisplayValue.replace(titleCaseRegex, match => match.toUpperCase());
 };
 
-const removedUnrequiredWords = (companyTypeKey: string, editedDisplayValue: string, displayValue: string): string => {
+const removeUnrequiredWords = (companyTypeKey: string, editedDisplayValue: string, displayValue: string): string => {
   const displayValueArray: string[] = editedDisplayValue.split(" ");
   const alphanumerickey: string = companyTypeKey.replace(nonAlphanumericRegex, " ");
   for (let index = 0; index < displayValueArray.length; index++) {

--- a/src/utils/company.type.display.procressor.ts
+++ b/src/utils/company.type.display.procressor.ts
@@ -3,45 +3,45 @@ const titleCaseRegex = /(^\w{1})|(\s{1}\w{1})/g;
 const allowedCharacters = /[/]+/g;
 const multipleSpaces = /[\s]+/g;
 
-export const editCompanyTypeDisplay = (companyTypeKey: string, display: string): string => {
-  let editedDisplay: string = removeNonAlphanumericChars(display);
-  editedDisplay = removedUnrequiredWords(companyTypeKey, editedDisplay, display);
-  if (editedDisplay.length === 0) {
-    return display;
+export const editCompanyTypeDisplay = (companyTypeKey: string, displayValue: string): string => {
+  let editedDisplayValue: string = removeNonAlphanumericChars(displayValue);
+  editedDisplayValue = removedUnrequiredWords(companyTypeKey, editedDisplayValue, displayValue);
+  if (editedDisplayValue.length === 0) {
+    return displayValue;
   }
-  return ensureTitleCase(editedDisplay);
+  return ensureTitleCase(editedDisplayValue);
 };
 
-const removeNonAlphanumericChars = (display: string): string => {
-  return display.replace(nonAlphanumericRegex, " ");
+const removeNonAlphanumericChars = (displayValue: string): string => {
+  return displayValue.replace(nonAlphanumericRegex, " ");
 };
 
-const ensureTitleCase = (editedDisplay: string): string => {
-  return editedDisplay.replace(titleCaseRegex, match => match.toUpperCase());
+const ensureTitleCase = (editedDisplayValue: string): string => {
+  return editedDisplayValue.replace(titleCaseRegex, match => match.toUpperCase());
 };
 
-const removedUnrequiredWords = (companyTypeKey: string, editedDisplay: string, display: string): string => {
-  const displayArray: string[] = editedDisplay.split(" ");
+const removedUnrequiredWords = (companyTypeKey: string, editedDisplayValue: string, displayValue: string): string => {
+  const displayValueArray: string[] = editedDisplayValue.split(" ");
   const alphanumerickey: string = companyTypeKey.replace(nonAlphanumericRegex, " ");
-  for (let index = 0; index < displayArray.length; index++) {
-    const singleWord: string = displayArray[index];
+  for (let index = 0; index < displayValueArray.length; index++) {
+    const singleWord: string = displayValueArray[index];
     if (!alphanumerickey.toLowerCase().includes(singleWord.toLowerCase())) {
-      editedDisplay = handleAllowNonAlphanumericChars(singleWord, editedDisplay, display);
+      editedDisplayValue = handleAllowNonAlphanumericChars(singleWord, editedDisplayValue, displayValue);
     }
   }
-  return removeExcessWhitespaces(editedDisplay);
+  return removeExcessWhitespaces(editedDisplayValue);
 };
 
-const handleAllowNonAlphanumericChars = (singleWord: string, editedDisplay: string, display: string): string => {
-  if (display.match(allowedCharacters)){
-    return display.replace(singleWord, "");
+const handleAllowNonAlphanumericChars = (singleWord: string, editedDisplayValue: string, displayValue: string): string => {
+  if (displayValue.match(allowedCharacters)){
+    return displayValue.replace(singleWord, "");
   } else {
-    return editedDisplay.replace(singleWord, "");
+    return editedDisplayValue.replace(singleWord, "");
   }
 };
 
-const removeExcessWhitespaces = (editedDisplay: string): string => {
-  editedDisplay = editedDisplay.replace(multipleSpaces, " ");
-  return editedDisplay.trim();
+const removeExcessWhitespaces = (editedDisplayValue: string): string => {
+  editedDisplayValue = editedDisplayValue.replace(multipleSpaces, " ");
+  return editedDisplayValue.trim();
 };
 

--- a/src/utils/company.type.display.procressor.ts
+++ b/src/utils/company.type.display.procressor.ts
@@ -1,0 +1,47 @@
+const nonAlphanumericRegex = /[^a-zA-Z0-9\s]+/g;
+const titleCaseRegex = /(^\w{1})|(\s{1}\w{1})/g;
+const allowedCharacters = /[/]+/g;
+const multipleSpaces = /[\s]+/g;
+
+export const editCompanyTypeDisplay = (companyTypeKey: string, display: string): string => {
+  let editedDisplay: string = removeNonAlphanumericChars(display);
+  editedDisplay = removedUnrequiredWords(companyTypeKey, editedDisplay, display);
+  if (editedDisplay.length === 0) {
+    return display;
+  }
+  return ensureTitleCase(editedDisplay);
+};
+
+const removeNonAlphanumericChars = (display: string): string => {
+  return display.replace(nonAlphanumericRegex, " ");
+};
+
+const ensureTitleCase = (editedDisplay: string): string => {
+  return editedDisplay.replace(titleCaseRegex, match => match.toUpperCase());
+};
+
+const removedUnrequiredWords = (companyTypeKey: string, editedDisplay: string, display: string): string => {
+  const displayArray: string[] = editedDisplay.split(" ");
+  const alphanumerickey: string = companyTypeKey.replace(nonAlphanumericRegex, " ");
+  for (let index = 0; index < displayArray.length; index++) {
+    const singleWord: string = displayArray[index];
+    if (!alphanumerickey.toLowerCase().includes(singleWord.toLowerCase())) {
+      editedDisplay = handleAllowNonAlphanumericChars(singleWord, editedDisplay, display);
+    }
+  }
+  return removeExcessWhitespaces(editedDisplay);
+};
+
+const handleAllowNonAlphanumericChars = (singleWord: string, editedDisplay: string, display: string): string => {
+  if (display.match(allowedCharacters)){
+    return display.replace(singleWord, "");
+  } else {
+    return editedDisplay.replace(singleWord, "");
+  }
+};
+
+const removeExcessWhitespaces = (editedDisplay: string): string => {
+  editedDisplay = editedDisplay.replace(multipleSpaces, " ");
+  return editedDisplay.trim();
+};
+

--- a/test/utils/api.enumerations.unit.ts
+++ b/test/utils/api.enumerations.unit.ts
@@ -1,8 +1,8 @@
 const READABLE_COMPANY_STATUS = "Receiver Action";
-const READABLE_COMPANY_TYPE = "Private limited company";
+const READABLE_COMPANY_TYPE = "Private Limited Company";
 const KEY_RECEIVERSHIP = "receivership";
 const KEY_LTD = "ltd";
-const KEY = "key";
+const KEY = "Key";
 
 jest.mock("js-yaml", () => {
   return {

--- a/test/utils/company.type.display.procressor.unit.ts
+++ b/test/utils/company.type.display.procressor.unit.ts
@@ -1,0 +1,38 @@
+import { editCompanyTypeDisplay } from "../../src/utils/company.type.display.procressor";
+
+describe("company type display processing tests", () => {
+  it ("should return value where wording is same as the key", () => {
+    const processed: string = editCompanyTypeDisplay("industrial-and-provident-society", "Industrial and Provident Society");
+    expect(processed).toEqual("Industrial And Provident Society");
+  });
+
+  it ("should retain forward slash post processing", () => {
+    const processed: string = editCompanyTypeDisplay("converted-or-closed", "Converted/closed company");
+    expect(processed).toEqual("Converted/closed");
+  });
+
+  it ("should remove excess words not present in type key", () => {
+    const processed: string = editCompanyTypeDisplay("scottish-partnership", "Scottish qualifying partnership");
+    expect(processed).toEqual("Scottish Partnership");
+  });
+
+  it ("should process even when no value is present for the key", () => {
+    const processed: string = editCompanyTypeDisplay("united-kingdom-societas", "united-kingdom-societas");
+    expect(processed).toEqual("United Kingdom Societas");
+  });
+
+  it ("should return value when present for abbreviated key", () => {
+    let processed: string = editCompanyTypeDisplay("ltd", "Private limited Company");
+    expect(processed).toEqual("Private limited Company");
+    processed = editCompanyTypeDisplay("plc", "Public limited Company");
+    expect(processed).toEqual("Public limited Company");
+    processed = editCompanyTypeDisplay("llp", "Limited liability partnership");
+    expect(processed).toEqual("Limited liability partnership");
+    processed = editCompanyTypeDisplay("icvc-securities", "Investment company with variable capital");
+    expect(processed).toEqual("Investment company with variable capital");
+    processed = editCompanyTypeDisplay("icvc-warrant", "Investment company with variable capital");
+    expect(processed).toEqual("Investment company with variable capital");
+    processed = editCompanyTypeDisplay("icvc-umbrella", "Investment company with variable capital");
+    expect(processed).toEqual("Investment company with variable capital");
+  });
+});


### PR DESCRIPTION
In relation to the issues on the ticket:
Covered in unit and dev tests:

8 Converted/Closed – now returns Converted/Closed

30 Scottish Partnership – now returns Scottish Partnership 

26 United Kingdom Societas  - now returns United Kingdom Societas

Dev tested:

Uk-establishment – returns UK Establishment 

Not resolved:

36 United Kingdom Economic Interest Grouping - (ukeig)
19 Other type of company (in Northern Ireland)

The problem with these is down to the data we have in api-enumerations.