### PR TITLE
NCS-381 Trading status missing text

### DIFF
--- a/src/controllers/trading.status.controller.ts
+++ b/src/controllers/trading.status.controller.ts
@@ -6,8 +6,10 @@ import { TRADING_STATUS_ERROR } from "../utils/constants";
 export const get = (req: Request, res: Response) => {
   const companyNumber =  req.params[urlParams.PARAM_COMPANY_NUMBER];
   const backLinkUrl = `${CONFIRM_COMPANY_PATH}?companyNumber=${companyNumber}`;
+  const tradingStatus = "0";
   return res.render(Templates.TRADING_STATUS, {
-    backLinkUrl
+    backLinkUrl,
+    tradingStatus
   });
 };
 

--- a/test/controllers/trading.status.controller.unit.ts
+++ b/test/controllers/trading.status.controller.unit.ts
@@ -23,6 +23,7 @@ describe("Trading status controller tests", () => {
     const url = TRADING_STATUS_PATH.replace(":companyNumber", COMPANY_NUMBER);
     const response = await request(app).get(url);
     expect(response.text).toContain(PAGE_HEADING);
+    expect(response.text).toContain("No company shares were traded on a market during this confirmation period.");
   });
 
   it("Should navigate to the task list page when trading status is correct", async () => {

--- a/views/check-trading-status.html
+++ b/views/check-trading-status.html
@@ -41,26 +41,10 @@
         <h1 class="govuk-heading-xl">Check the trading status</h1>
 
 
-        {% if scenario.company.tradingStatus === '1' %}
-          <p>No company shares were traded on a market during this confirmation period</p>
-        {% elseif scenario.company.tradingStatus === '2' %}
-          <p>Company shares were traded on a market, and the company has not been subject to DTR5, during this confirmation statement period</p>
-        {% elseif scenario.company.tradingStatus === '3' %}
-          <p>Company shares were traded on a market, and the company has been subject to DTR5, during this confirmation statement period</p>
+        {% if tradingStatus === '0' %}
+          <p>No company shares were traded on a market during this confirmation period.</p>
         {% endif %}
 
-        {% set dtrDetails %}
-          <p>DTR5 refers to Vote Holder and Issuer Notification Rules in
-            <a href="https://www.handbook.fca.org.uk/handbook/DTR/5.pdf">Chapter 5 of the Financial Conduct Authority's Disclosure and Transparency Rules</a>.</p>
-          <p>It applies to UK companies with shares traded on a market. Under DTR5, shareholders must notify the company if their shareholding reaches or falls below certain percentage thresholds (starting at 3%).</p>
-        {% endset %}
-
-        {% if scenario.company.tradingStatus === '2' or scenario.company.tradingStatus === '3' %}
-          {{ govukDetails({
-             summaryText: "What is DTR5?",
-             html: dtrDetails
-          }) }}
-        {% endif %}
           <br/>
         {{ govukRadios({
           classes: "govuk-radios--inline",


### PR DESCRIPTION
Ticket updated with: For MVP we are not doing validation on the CORPORATE_BODY.COMPANY_TRADED_TYPE_ID thereofre the criterion is just to display the missing text.