### PR TITLE
NCS-389 Paper filing links need to vary on the stop page

### DIFF
--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -162,6 +162,33 @@ describe("Confirm company controller tests", () => {
     expect(response.status).toEqual(200);
     expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
     expect(response.text).toContain("You cannot use this service - File a confirmation statement");
+    expect(response.text).toContain("https://www.gov.uk/government/publications/confirmation-statement-cs01");
+  });
+
+  it("Should redirect to use paper stop screen when the eligibility status code is INVALID_COMPANY_TYPE_PAPER_FILING_ONLY, type scottish-partnership", async () => {
+    validCompanyProfile.type  = "scottish-partnership";
+    mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
+    mockIsActiveFeature.mockReturnValueOnce(true);
+    mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.INVALID_COMPANY_TYPE_PAPER_FILING_ONLY);
+    const response = await request(app)
+      .post(CONFIRM_COMPANY_PATH);
+    expect(response.status).toEqual(200);
+    expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
+    expect(response.text).toContain("You cannot use this service - File a confirmation statement");
+    expect(response.text).toContain("https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01");
+  });
+
+  it("Should redirect to use paper stop screen when the eligibility status code is INVALID_COMPANY_TYPE_PAPER_FILING_ONLY, type limited-partnership", async () => {
+    validCompanyProfile.type  = "limited-partnership";
+    mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
+    mockIsActiveFeature.mockReturnValueOnce(true);
+    mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.INVALID_COMPANY_TYPE_PAPER_FILING_ONLY);
+    const response = await request(app)
+      .post(CONFIRM_COMPANY_PATH);
+    expect(response.status).toEqual(200);
+    expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
+    expect(response.text).toContain("You cannot use this service - File a confirmation statement");
+    expect(response.text).toContain("https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-limited-partnership-slp-cs01");
   });
 
   it("Should redirect to use no filing required stop screen when the eligibility status code is INVALID_COMPANY_TYPE_CS01_FILING_NOT_REQUIRED", async () => {

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -166,12 +166,14 @@ describe("Confirm company controller tests", () => {
   });
 
   it("Should redirect to use paper stop screen when the eligibility status code is INVALID_COMPANY_TYPE_PAPER_FILING_ONLY, type scottish-partnership", async () => {
+    const originalType = validCompanyProfile.type;
     validCompanyProfile.type  = "scottish-partnership";
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockIsActiveFeature.mockReturnValueOnce(true);
     mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.INVALID_COMPANY_TYPE_PAPER_FILING_ONLY);
     const response = await request(app)
       .post(CONFIRM_COMPANY_PATH);
+    validCompanyProfile.type  = originalType;
     expect(response.status).toEqual(200);
     expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
     expect(response.text).toContain("You cannot use this service - File a confirmation statement");
@@ -179,12 +181,14 @@ describe("Confirm company controller tests", () => {
   });
 
   it("Should redirect to use paper stop screen when the eligibility status code is INVALID_COMPANY_TYPE_PAPER_FILING_ONLY, type limited-partnership", async () => {
+    const originalType = validCompanyProfile.type;
     validCompanyProfile.type  = "limited-partnership";
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockIsActiveFeature.mockReturnValueOnce(true);
     mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.INVALID_COMPANY_TYPE_PAPER_FILING_ONLY);
     const response = await request(app)
       .post(CONFIRM_COMPANY_PATH);
+    validCompanyProfile.type  = originalType;
     expect(response.status).toEqual(200);
     expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
     expect(response.text).toContain("You cannot use this service - File a confirmation statement");

--- a/views/paper-filing.html
+++ b/views/paper-filing.html
@@ -13,14 +13,14 @@
       <p>{{ company.companyName }} is a {{ company.type }}, which means it can only file confirmation statements using the
 
         {% if company.type === "limited-partnership" %}
-          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-limited-partnership-slp-cs01"/>
+          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-limited-partnership-slp-cs01"/>SLP CSO1 confirmation statement paper form</a>.
         {% elseif company.type === "scottish-partnership" %}
-          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01"/>
+          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01"/>SQP CSO1 confirmation statement paper form</a>.
         {% else %}
-           <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01"/>
+           <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01">CS01 confirmation statement paper form</a>.
         {% endif %}
 
-        CS01 confirmation statement paper form</a>. This can be submitted online using our <a href="https://find-and-update.company-information.service.gov.uk/efs-submission/start">Upload a document to Companies House</a> service.</p>
+        This can be submitted online using our <a href="https://find-and-update.company-information.service.gov.uk/efs-submission/start">Upload a document to Companies House</a> service.</p>
 
       <p><a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening">Contact us if you think this information is wrong</a>.</p>
       <p>If this is the wrong company, start the <a href="/confirmation-statement">File a confirmation statement</a> service again.</p>

--- a/views/paper-filing.html
+++ b/views/paper-filing.html
@@ -10,7 +10,17 @@
       <h1 class="govuk-heading-xl">
         You cannot use this service
       </h1>
-      <p>{{ company.companyName }} is a {{ company.type }}, which means it can only file confirmation statements using the <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01">CS01 confirmation statement paper form</a>. This can be submitted online using our <a href="https://find-and-update.company-information.service.gov.uk/efs-submission/start">Upload a document to Companies House</a> service.</p>
+      <p>{{ company.companyName }} is a {{ company.type }}, which means it can only file confirmation statements using the
+
+        {% if company.type === "limited-partnership" %}
+          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-limited-partnership-slp-cs01"/>
+        {% elseif company.type === "scottish-partnership" %}
+          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01"/>
+        {% else %}
+           <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01"/>
+        {% endif %}
+
+        CS01 confirmation statement paper form</a>. This can be submitted online using our <a href="https://find-and-update.company-information.service.gov.uk/efs-submission/start">Upload a document to Companies House</a> service.</p>
 
       <p><a href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening">Contact us if you think this information is wrong</a>.</p>
       <p>If this is the wrong company, start the <a href="/confirmation-statement">File a confirmation statement</a> service again.</p>


### PR DESCRIPTION
Scottish paper filing companies SLP and SQP have differnet links on the CS01 stop page where :

Scottish limited partnership (SLP) should map to Limited partnership
Scottish qualifying partnership (SQP) should map to Scottish partnership