### PR TITLE
NCS-404 Updated Trading Status Navigation

### DIFF
--- a/test/controllers/trading.status.controller.unit.ts
+++ b/test/controllers/trading.status.controller.unit.ts
@@ -23,6 +23,7 @@ describe("Trading status controller tests", () => {
     const url = TRADING_STATUS_PATH.replace(":companyNumber", COMPANY_NUMBER);
     const response = await request(app).get(url);
     expect(response.text).toContain(PAGE_HEADING);
+    expect(response.text).toContain("No company shares were traded on a market during this confirmation period.");
   });
 
   it("Should navigate to the task list page when trading status is correct", async () => {
@@ -54,5 +55,6 @@ describe("Trading status controller tests", () => {
     expect(response.header.location).not.toEqual("/confirmation-statement/company/12345678/task-list");
     expect(response.text).toContain(PAGE_HEADING);
     expect(response.text).toContain(TRADING_STATUS_ERROR);
+    expect(response.text).toContain("No company shares were traded on a market during this confirmation period.");
   });
 });

--- a/views/check-trading-status.html
+++ b/views/check-trading-status.html
@@ -40,7 +40,8 @@
 
         <h1 class="govuk-heading-xl">Check the trading status of shares</h1>
 
-          <br/>
+        <p>No company shares were traded on a market during this confirmation period.</p>
+
         {{ govukRadios({
           classes: "govuk-radios--inline",
           idPrefix: "trading-status",


### PR DESCRIPTION
Checked thourgh the acceptance criteria and found that changes are needed for AC 5 only. Here we reintrodued the line added in NCS-381 minus the status checks as only those with code 0 CompanyTradedStatusType.NOT_ADMITTED_TO_TRADING will get to this page.