### PR TITLE
NCS-420 Add company name to invalid company status stop screen

### DIFF
--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -96,12 +96,14 @@ describe("Confirm company controller tests", () => {
 
   it("Should render eligibility error page when company status is not valid", async () => {
     mockIsActiveFeature.mockReturnValueOnce(true);
+    mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.INVALID_COMPANY_STATUS);
     const response = await request(app)
       .post(CONFIRM_COMPANY_PATH);
     expect(response.status).toEqual(200);
     expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
     expect(response.text).toContain("dissolved and struck off the register");
+    expect(response.text).toContain(`cannot be filed for ${validCompanyProfile.companyName}`);
   });
 
   it("Should redirect to error page when unrecognised eligibility code is returned", async () => {

--- a/views/invalid-company-status.html
+++ b/views/invalid-company-status.html
@@ -10,7 +10,7 @@ You cannot file a confirmation statement - File a confirmation statement
         <h1 class="govuk-heading-xl">
             You cannot file a confirmation statement
         </h1>
-        <p>A confirmation statement cannot be filed for {{ companyName }} because it:</p>
+        <p>A confirmation statement cannot be filed for {{ company.companyName }} because it:</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>has been dissolved and struck off the register</li>
             <li>is in the process of being dissolved and struck off the register</li>


### PR DESCRIPTION
The invalid company status stop screen wasn't showing the company name so this is to fix it.