### PR TITLE
NCS 446 retrieve officer details for active officer page 

### DIFF
--- a/src/controllers/tasks/active.officers.controller.ts
+++ b/src/controllers/tasks/active.officers.controller.ts
@@ -1,10 +1,17 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import { Templates } from "../../types/template.paths";
 import { TASK_LIST_PATH, urlParams } from "../../types/page.urls";
 import { urlUtils } from "../../utils/url";
+import { CompanyOfficers } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
+import { getCompanyOfficers } from "../../services/company.officers.service";
 
-export const get = (req: Request, res: Response) => {
-  const companyNumber = req.params[urlParams.PARAM_COMPANY_NUMBER];
-  const backLinkUrl = urlUtils.getUrlWithCompanyNumber(TASK_LIST_PATH, companyNumber);
-  return res.render(Templates.ACTIVE_OFFICERS, { backLinkUrl });
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const companyNumber = req.params[urlParams.PARAM_COMPANY_NUMBER];
+    const backLinkUrl = urlUtils.getUrlWithCompanyNumber(TASK_LIST_PATH, companyNumber);
+    const companyOfficers: CompanyOfficers = await getCompanyOfficers(companyNumber);
+    return res.render(Templates.ACTIVE_OFFICERS, { backLinkUrl, companyOfficers });
+  } catch (e) {
+    return next(e);
+  }
 };

--- a/src/controllers/tasks/active.officers.controller.ts
+++ b/src/controllers/tasks/active.officers.controller.ts
@@ -2,6 +2,9 @@ import { NextFunction, Request, Response } from "express";
 import { Templates } from "../../types/template.paths";
 import { TASK_LIST_PATH, urlParams } from "../../types/page.urls";
 import { urlUtils } from "../../utils/url";
+import { FEATURE_FLAG_ACTIVE_OFFICERS_01072021 } from "../../utils/properties";
+import { isActiveFeature } from "../../utils/feature.flag";
+import { validDummyCompanyOfficers } from "../../utils/dummy.company.officers";
 import { CompanyOfficers } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
 import { getCompanyOfficers } from "../../services/company.officers.service";
 
@@ -9,7 +12,12 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const companyNumber = req.params[urlParams.PARAM_COMPANY_NUMBER];
     const backLinkUrl = urlUtils.getUrlWithCompanyNumber(TASK_LIST_PATH, companyNumber);
-    const companyOfficers: CompanyOfficers = await getCompanyOfficers(companyNumber);
+    let companyOfficers: CompanyOfficers;
+    if (isActiveFeature(FEATURE_FLAG_ACTIVE_OFFICERS_01072021)){
+      companyOfficers = await getCompanyOfficers(companyNumber);
+    } else {
+      companyOfficers = validDummyCompanyOfficers;
+    }
     return res.render(Templates.ACTIVE_OFFICERS, { backLinkUrl, companyOfficers });
   } catch (e) {
     return next(e);

--- a/src/services/company.officers.service.ts
+++ b/src/services/company.officers.service.ts
@@ -1,0 +1,27 @@
+import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
+import { CompanyOfficers } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
+import { CHS_API_KEY } from "../utils/properties";
+import { logger, createAndLogError } from "../utils/logger";
+
+export const getCompanyOfficers = async (companyNumber: string): Promise<CompanyOfficers> => {
+  const apiClient = createApiClient(CHS_API_KEY);
+
+  logger.debug(`Looking for company officers with company number ${companyNumber}`);
+  const sdkResponse: Resource<CompanyOfficers> = await apiClient.companyOfficers.getCompanyOfficers(companyNumber);
+
+  if (!sdkResponse) {
+    throw createAndLogError(`Company Officers API returned no response for company number ${companyNumber}`);
+  }
+
+  if (sdkResponse.httpStatusCode >= 400) {
+    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to get company officers for company number ${companyNumber}`);
+  }
+
+  if (!sdkResponse.resource) {
+    throw createAndLogError(`Company Officers API returned no resource for company number ${companyNumber}`);
+  }
+
+  logger.debug(`Received company officers for company number ${companyNumber} : ${JSON.stringify(sdkResponse)}`);
+
+  return sdkResponse.resource;
+};

--- a/src/utils/dummy.company.officers.ts
+++ b/src/utils/dummy.company.officers.ts
@@ -1,0 +1,37 @@
+import { CompanyOfficers } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
+
+export const validDummyCompanyOfficers: CompanyOfficers = {
+  resignedCount: "1",
+  inactiveCount: "0",
+  links: {
+    self: ""
+  },
+  items: [
+    {
+      links: {
+        officer: {
+          appointments: "",
+        }
+      },
+      address: {
+        addressLine1: "Flat D 379 Clapham Road",
+        addressLine2: "",
+        country: "UK",
+        postalCode: "SW9 9BT",
+        locality: "London"
+      },
+      nationality: "British",
+      name: "Crocodile DICTIONRIVULET",
+      officerRole: "director",
+      resignedOn: "2009-12-04",
+      occupation: "Personal Assistant",
+      appointedOn: "2006-04-03",
+    }
+  ],
+  activeCount: "0",
+  totalResults: "1",
+  etag: "66911f2efbdc0df65480a4e5443940db0ad9e7c3",
+  itemsPerPage: "1",
+  startIndex: "1",
+  kind: "",
+};

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -33,4 +33,6 @@ export const INTERNAL_API_URL = getEnvironmentVariable("INTERNAL_API_URL");
 
 export const FEATURE_FLAG_PRIVATE_SDK_12052021 = getEnvironmentVariable("FEATURE_FLAG_PRIVATE_SDK_12052021");
 
+export const FEATURE_FLAG_ACTIVE_OFFICERS_01072021 = getEnvironmentVariable("FEATURE_FLAG_ACTIVE_OFFICERS_01072021", true);
+
 export const PIWIK_START_GOAL_ID = getEnvironmentVariable("PIWIK_START_GOAL_ID");

--- a/test/controllers/tasks/active.officers.controller.unit.ts
+++ b/test/controllers/tasks/active.officers.controller.unit.ts
@@ -5,12 +5,15 @@ import { ACTIVE_OFFICERS_PATH } from "../../../src/types/page.urls";
 import { companyAuthenticationMiddleware } from "../../../src/middleware/company.authentication.middleware";
 import { validCompanyOfficers } from "../../mocks/company.officers.mock";
 import { getCompanyOfficers } from "../../../src/services/company.officers.service";
+import { isActiveFeature } from "../../../src/utils/feature.flag";
 
 jest.mock("../../../src/middleware/company.authentication.middleware");
 jest.mock("../../../src/services/company.officers.service");
+jest.mock("../../../src/utils/feature.flag");
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
 const mockGetCompanyOfficers = getCompanyOfficers as jest.Mock;
+const mockIsActiveFeature = isActiveFeature as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
 
 const COMPANY_NUMBER = "12345678";
@@ -25,6 +28,7 @@ describe("Active officers controller tests", () => {
   });
 
   it("Should return active officers page", async () => {
+    mockIsActiveFeature.mockReturnValueOnce(true);
     mockGetCompanyOfficers.mockResolvedValueOnce(validCompanyOfficers);
     const response = await request(app).get(url);
     expect(response.text).toContain(EXPECTED_TEXT);
@@ -33,7 +37,14 @@ describe("Active officers controller tests", () => {
   it("Should return error page if active officers cannot be retired", async () => {
     const message = "Can't connect";
     mockGetCompanyOfficers.mockRejectedValueOnce(new Error(message));
+    mockIsActiveFeature.mockReturnValueOnce(true);
     const response = await request(app).get(url);
     expect(response.text).toContain(EXPECTED_ERROR_TEXT);
+  });
+
+  it("Should skip officer check and return active officers page if feature flag is off", async () => {
+    mockIsActiveFeature.mockReturnValueOnce(false);
+    const response = await request(app).get(url);
+    expect(response.text).toContain(EXPECTED_TEXT);
   });
 });

--- a/test/controllers/tasks/active.officers.controller.unit.ts
+++ b/test/controllers/tasks/active.officers.controller.unit.ts
@@ -3,16 +3,20 @@ import request from "supertest";
 import app from "../../../src/app";
 import { ACTIVE_OFFICERS_PATH } from "../../../src/types/page.urls";
 import { companyAuthenticationMiddleware } from "../../../src/middleware/company.authentication.middleware";
-import { urlUtils } from "../../../src/utils/url";
+import { validCompanyOfficers } from "../../mocks/company.officers.mock";
+import { getCompanyOfficers } from "../../../src/services/company.officers.service";
 
 jest.mock("../../../src/middleware/company.authentication.middleware");
+jest.mock("../../../src/services/company.officers.service");
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
+const mockGetCompanyOfficers = getCompanyOfficers as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
 
 const COMPANY_NUMBER = "12345678";
 const EXPECTED_TEXT = "Review the directors";
 const EXPECTED_ERROR_TEXT = "Sorry, the service is unavailable";
+const url = ACTIVE_OFFICERS_PATH.replace(":companyNumber", COMPANY_NUMBER);
 
 describe("Active officers controller tests", () => {
 
@@ -20,21 +24,16 @@ describe("Active officers controller tests", () => {
     mocks.mockAuthenticationMiddleware.mockClear();
   });
 
-  it("should return active officers page", async () => {
-    const url = ACTIVE_OFFICERS_PATH.replace(":companyNumber", COMPANY_NUMBER);
+  it("Should return active officers page", async () => {
+    mockGetCompanyOfficers.mockResolvedValueOnce(validCompanyOfficers);
     const response = await request(app).get(url);
     expect(response.text).toContain(EXPECTED_TEXT);
   });
 
-  it("Should return an error page if error is thrown when Company Profile is missing confirmation statement", async () => {
-    const spyGetUrlWithCompanyNumber = jest.spyOn(urlUtils, "getUrlWithCompanyNumber");
-    spyGetUrlWithCompanyNumber.mockImplementationOnce(() => { throw new Error(); });
-    const url = ACTIVE_OFFICERS_PATH.replace(":companyNumber", COMPANY_NUMBER);
+  it("Should return error page if active officers cannot be retired", async () => {
+    const message = "Can't connect";
+    mockGetCompanyOfficers.mockRejectedValueOnce(new Error(message));
     const response = await request(app).get(url);
-
     expect(response.text).toContain(EXPECTED_ERROR_TEXT);
-
-    // restore original function so it is no longer mocked
-    spyGetUrlWithCompanyNumber.mockRestore();
   });
 });

--- a/test/mocks/company.officers.mock.ts
+++ b/test/mocks/company.officers.mock.ts
@@ -1,0 +1,43 @@
+import { Resource } from "@companieshouse/api-sdk-node";
+import { CompanyOfficers } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
+
+export const validCompanyOfficers: CompanyOfficers = {
+  resignedCount: "1",
+  inactiveCount: "0",
+  links: {
+    self: ""
+  },
+  items: [
+    {
+      links: {
+        officer: {
+          appointments: "",
+        }
+      },
+      address: {
+        addressLine1: "Flat D 379 Clapham Road",
+        addressLine2: "",
+        country: "UK",
+        postalCode: "SW9 9BT",
+        locality: "London"
+      },
+      nationality: "British",
+      name: "Crocodile DICTIONRIVULET",
+      officerRole: "director",
+      resignedOn: "2009-12-04",
+      occupation: "Personal Assistant",
+      appointedOn: "2006-04-03",
+    }
+  ],
+  activeCount: "0",
+  totalResults: "1",
+  etag: "66911f2efbdc0df65480a4e5443940db0ad9e7c3",
+  itemsPerPage: "1",
+  startIndex: "1",
+  kind: "",
+};
+
+export const validSDKResource: Resource<CompanyOfficers> = {
+  httpStatusCode: 200,
+  resource: validCompanyOfficers,
+};

--- a/test/services/company.officers.service.unit.ts
+++ b/test/services/company.officers.service.unit.ts
@@ -1,0 +1,101 @@
+jest.mock("@companieshouse/api-sdk-node");
+jest.mock("../../src/utils/logger");
+jest.mock("../../src/utils/api.enumerations");
+
+import { getCompanyOfficers } from "../../src/services/company.officers.service";
+import { createApiClient, Resource } from "@companieshouse/api-sdk-node";
+import { createAndLogError } from "../../src/utils/logger";
+import { validSDKResource } from "../mocks/company.officers.mock";
+import { CompanyOfficers } from "@companieshouse/api-sdk-node/dist/services/company-officers/types";
+
+const mockCreateApiClient = createApiClient as jest.Mock;
+const mockGetCompanyOfficers = jest.fn();
+const mockCreateAndLogError = createAndLogError as jest.Mock;
+
+mockCreateApiClient.mockReturnValue({
+  companyOfficers: {
+    getCompanyOfficers: mockGetCompanyOfficers
+  }
+});
+
+mockCreateAndLogError.mockReturnValue(new Error());
+
+const clone = (objectToClone: any): any => {
+  return JSON.parse(JSON.stringify(objectToClone));
+};
+
+describe("Company Officers Service Test", () => {
+  const COMPANY_NUMBER = "1234567";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("getCompanyOfficers should return company officers", async () => {
+    mockGetCompanyOfficers.mockResolvedValueOnce(clone(validSDKResource));
+    const returnedProfile: CompanyOfficers = await getCompanyOfficers(COMPANY_NUMBER);
+
+    Object.getOwnPropertyNames(validSDKResource.resource).forEach(property => {
+      expect(returnedProfile).toHaveProperty(property);
+    });
+  });
+
+  it("getCompanyOfficers should throw an error if status code == 400", async () => {
+    const HTTP_STATUS_CODE = 400;
+    mockGetCompanyOfficers.mockResolvedValueOnce({
+      httpStatusCode: HTTP_STATUS_CODE
+    } as Resource<CompanyOfficers>);
+
+    await getCompanyOfficers(COMPANY_NUMBER)
+      .then(() => {
+        fail("Expected an error to be thrown.");
+      })
+      .catch(() => {
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${HTTP_STATUS_CODE}`));
+      });
+  });
+
+  it("getCompanyOfficers should throw an error if status code > 400", async () => {
+    const HTTP_STATUS_CODE = 502;
+    mockGetCompanyOfficers.mockResolvedValueOnce({
+      httpStatusCode: HTTP_STATUS_CODE
+    } as Resource<CompanyOfficers>);
+
+    await getCompanyOfficers(COMPANY_NUMBER)
+      .then(() => {
+        fail("Expected an error to be thrown.");
+      })
+      .catch(() => {
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${HTTP_STATUS_CODE}`));
+      });
+  });
+
+  it("getCompanyOfficers should throw an error if no response returned from SDK", async () => {
+    mockGetCompanyOfficers.mockResolvedValueOnce(undefined);
+
+    await getCompanyOfficers(COMPANY_NUMBER)
+      .then(() => {
+        fail("Expected an error to be thrown.");
+      })
+      .catch(() => {
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("no response"));
+      });
+  });
+
+  it("getCompanyOfficers should throw an error if no response resource returned from SDK", async () => {
+    mockGetCompanyOfficers.mockResolvedValueOnce({} as Resource<CompanyOfficers>);
+
+    await getCompanyOfficers(COMPANY_NUMBER)
+      .then(() => {
+        fail("Expected an error to be thrown.");
+      })
+      .catch(() => {
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining(`${COMPANY_NUMBER}`));
+        expect(createAndLogError).toHaveBeenCalledWith(expect.stringContaining("no resource"));
+      });
+  });
+
+});


### PR DESCRIPTION
Implement officer service to retrieve officers details from CH API 

Added feature flag due to lack of officer data in dev environments if true fetch will be made on officer data if false dummy officer data will be used. Config update is ready to be merged if this PR is approved 