### PR TITLE
NCS-443 Matomo event tracking on ROA page.

### DIFF
--- a/views/check-trading-status.html
+++ b/views/check-trading-status.html
@@ -72,14 +72,8 @@
           ]
         }) }}
 
-        {{ govukButton({
-          text: "Continue",
-            attributes: {
-              "data-event-id": "continue-button",
-              "id": "submit"
-            }
-          })
-        }}
+        {% include "includes/continue-button.html" %}
+        
       </form>
     </div>
 </div>

--- a/views/includes/continue-button.html
+++ b/views/includes/continue-button.html
@@ -1,5 +1,3 @@
-<p class="govuk-body-m">
-
 {{ govukButton({
     text: "Continue",
     attributes: {
@@ -7,5 +5,3 @@
         "id": "submit"
     }
 }) }}
-
-</p>

--- a/views/includes/continue-button.html
+++ b/views/includes/continue-button.html
@@ -1,0 +1,11 @@
+<p class="govuk-body-m">
+
+{{ govukButton({
+    text: "Continue",
+    attributes: {
+        "data-event-id": "continue-button",
+        "id": "submit"
+    }
+}) }}
+
+</p>

--- a/views/tasks/active-officers.html
+++ b/views/tasks/active-officers.html
@@ -81,9 +81,9 @@
             }
           ]
         }) }}
-        {{ govukButton({
-          text: "Continue"
-        }) }}
+        
+        {% include "includes/continue-button.html" %}
+        
       </form>
     </div>
   </div>

--- a/views/tasks/active-pscs.html
+++ b/views/tasks/active-pscs.html
@@ -71,9 +71,8 @@
                     }
                   ]
                 }) }}
-                {{ govukButton({
-                   text: "Continue"
-                }) }}
+                
+                {% include "includes/continue-button.html" %}
 
             </form>
         </div>

--- a/views/tasks/registered-office-address.html
+++ b/views/tasks/registered-office-address.html
@@ -7,7 +7,10 @@
 {% block backLink %}
   {{ govukBackLink({
     text: "Back",
-    href: backLinkUrl
+    href: backLinkUrl,
+    attributes: {
+      "data-event-id": "back-link"
+    }
   }) }}
 {% endblock %}
 

--- a/views/tasks/registered-office-address.html
+++ b/views/tasks/registered-office-address.html
@@ -50,13 +50,8 @@
         ]
       }) }}
 
-      {{ govukButton({
-        text: "Continue",
-        attributes: {
-          "data-event-id": "continue-button",
-          "id": "submit"
-        }
-      }) }}
+      {% include "includes/continue-button.html" %}
+      
     </form>
   </div>
 </div>

--- a/views/tasks/sic.html
+++ b/views/tasks/sic.html
@@ -11,8 +11,8 @@
       text: "Back",
       href: backLinkUrl,
       attributes: {
-                "data-event-id": "back-button"
-              }
+        "data-event-id": "back-button"
+        }
   }) }}
 {% endblock %}
 

--- a/views/tasks/sic.html
+++ b/views/tasks/sic.html
@@ -80,14 +80,8 @@
               ]
           }) }}
 
-        {{ govukButton({
-            text: "Continue",
-            attributes: {
-                "data-event-id": "continue-button",
-                "id": "submit"
-              }
-          }) 
-        }}
+        {% include "includes/continue-button.html" %}
+
       </form>
     </div>
   </div>

--- a/views/tasks/statement-of-capital.html
+++ b/views/tasks/statement-of-capital.html
@@ -64,13 +64,7 @@
               ]
             }) }}
 
-            {{ govukButton({
-              text: "Continue",
-              attributes: {
-                "data-event-id": "continue-button",
-                "id": "submit"
-              }
-            }) }}
+            {% include "includes/continue-button.html" %}
         </form>
     </div>
 </div>


### PR DESCRIPTION
Add tracking event on Registered Office Address page.
Also refactored: Extracted "Continue" button to a file rather than have element duplicated across multiple pages.