### PR TITLE
NCS-282 Adding builder for confirmation statement submissions

### DIFF
--- a/src/types/builders/confirmation.statement.submission.builder.ts
+++ b/src/types/builders/confirmation.statement.submission.builder.ts
@@ -1,0 +1,38 @@
+import { ConfirmationStatementSubmission, StatementOfCapitalData } from "private-api-sdk-node/dist/services/confirmation-statement";
+
+const getBaseCSSubmission = (transactionId: string, csSubmissionId: string): ConfirmationStatementSubmission => {
+  return {
+    id: csSubmissionId,
+    links: {
+      self: `/transactions/${transactionId}/confirmation-statement/${csSubmissionId}`
+    }
+  };
+};
+
+export class ConfirmationStatementSubmissionBuilder {
+
+  private isBuildWithData: boolean = false;
+  private readonly transactionId: string;
+  private readonly csSubmissionId: string;
+  private statementOfCapitalData: StatementOfCapitalData;
+
+  constructor(transctionId: string, csSubmissionId: string) {
+    this.transactionId = transctionId;
+    this.csSubmissionId = csSubmissionId;
+  }
+
+  withStatementOfCapitalData = (statementOfCapitalData: StatementOfCapitalData) => {
+    this.statementOfCapitalData = statementOfCapitalData;
+    this.isBuildWithData = true;
+    return this;
+  };
+
+  build = () => {
+    const csSubmission: ConfirmationStatementSubmission = getBaseCSSubmission(this.transactionId, this.csSubmissionId);
+    if (this.isBuildWithData) {
+      csSubmission.data = {};
+      csSubmission.data.statementOfCapitalData = this.statementOfCapitalData;
+    }
+    return csSubmission;
+  };
+}

--- a/test/types/builders/confirmation.statement.submission.builder.unit.ts
+++ b/test/types/builders/confirmation.statement.submission.builder.unit.ts
@@ -1,0 +1,41 @@
+import { ConfirmationStatementSubmission, SectionStatus, StatementOfCapital } from "private-api-sdk-node/dist/services/confirmation-statement";
+import { ConfirmationStatementSubmissionBuilder } from "../../../src/types/builders/confirmation.statement.submission.builder";
+
+const TRANSACTION_ID = "735564";
+const CS_SUBMISSION_ID = "245435";
+
+describe("Confirmation Statement Submission Builder tests", () => {
+
+  it("Should build a basic ConfirmationStatementSubmission with no optionals ", () => {
+    const csSubmission: ConfirmationStatementSubmission = new ConfirmationStatementSubmissionBuilder(TRANSACTION_ID, CS_SUBMISSION_ID)
+      .build();
+
+    expect(csSubmission.id).toBe(CS_SUBMISSION_ID);
+    expect(csSubmission.links.self).toBe(`/transactions/${TRANSACTION_ID}/confirmation-statement/${CS_SUBMISSION_ID}`);
+  });
+
+  it("Should build a ConfirmationStatementSubmission with StatementOfCapitalData ", () => {
+    const statementOfCapital: StatementOfCapital = {
+      aggregateNominalValue: "1",
+      classOfShares: "2",
+      currency: "3",
+      numberAllotted: "4",
+      prescribedParticulars: "5",
+      totalAggregateNominalValue: "6",
+      totalAmountUnpaidForCurrency: "7",
+      totalNumberOfShares: "8"
+    };
+
+    const csSubmission: ConfirmationStatementSubmission = new ConfirmationStatementSubmissionBuilder(TRANSACTION_ID, CS_SUBMISSION_ID)
+      .withStatementOfCapitalData({
+        sectionStatus: SectionStatus.CONFIRMED,
+        statementOfCapital
+      })
+      .build();
+
+    expect(csSubmission.id).toBe(CS_SUBMISSION_ID);
+    expect(csSubmission.links.self).toBe(`/transactions/${TRANSACTION_ID}/confirmation-statement/${CS_SUBMISSION_ID}`);
+    expect(csSubmission.data?.statementOfCapitalData?.sectionStatus).toBe(SectionStatus.CONFIRMED);
+    expect(csSubmission.data?.statementOfCapitalData?.statementOfCapital).toBe(statementOfCapital);
+  });
+});


### PR DESCRIPTION
Adding a builder for creating confirmation statement submissions to keep the building in one place rather than in different controllers etc... 