### PR TITLE
NCS-282 Only sending statementOfCapital to Mongo when yes is selected (…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5694,8 +5694,8 @@
       }
     },
     "private-api-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#7a8cffbb9684a19399220f2974dfdd1ea46038d1",
-      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.33",
+      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#6b27b10725c47cc5fd23110622318c14fbe5751b",
+      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#ncs-282-make-soc-optional",
       "requires": {
         "@companieshouse/api-sdk-node": "^1.0.26",
         "camelcase-keys": "~6.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5694,8 +5694,8 @@
       }
     },
     "private-api-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#6b27b10725c47cc5fd23110622318c14fbe5751b",
-      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#ncs-282-make-soc-optional",
+      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#ac22915afbbcc60bc2065795d2e587aef7969786",
+      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.35",
       "requires": {
         "@companieshouse/api-sdk-node": "^1.0.26",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "luxon": "^1.27.0",
     "nunjucks": "^3.2.3",
     "on-headers": "^1.0.2",
-    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.33",
+    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#ncs-282-make-soc-optional",
     "safe-buffer": "^5.2.1",
     "yargs": "^15.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "luxon": "^1.27.0",
     "nunjucks": "^3.2.3",
     "on-headers": "^1.0.2",
-    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#ncs-282-make-soc-optional",
+    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.35",
     "safe-buffer": "^5.2.1",
     "yargs": "^15.3.1"
   },

--- a/test/controllers/tasks/statement.of.capital.controller.unit.ts
+++ b/test/controllers/tasks/statement.of.capital.controller.unit.ts
@@ -23,7 +23,7 @@ const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as j
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
 
 const mockGetStatementOfCapitalData = getStatementOfCapitalData as jest.Mock;
-const mockUpdateConfirmationStatement =  updateConfirmationStatement as jest.Mock;
+const mockUpdateConfirmationStatement = updateConfirmationStatement as jest.Mock;
 
 const mockGetConfirmationStatement = getConfirmationStatement as jest.Mock;
 

--- a/test/controllers/tasks/statement.of.capital.controller.unit.ts
+++ b/test/controllers/tasks/statement.of.capital.controller.unit.ts
@@ -18,6 +18,7 @@ import {
   mockConfirmationStatementSubmission,
   mockStatementOfCapital
 } from "../../mocks/confirmation.statement.submission.mock";
+import { ConfirmationStatementSubmission, SectionStatus } from "private-api-sdk-node/dist/services/confirmation-statement";
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
@@ -32,6 +33,7 @@ const STOP_PAGE_HEADING = "You cannot use this service - File a confirmation sta
 const COMPANY_NUMBER = "12345678";
 const SUBMISSION_ID = "a80f09e2";
 const TRANSACTION_ID = "111-111-111";
+const LINK_SELF = "/something";
 const STATEMENT_OF_CAPITAL_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(STATEMENT_OF_CAPITAL_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 const TASK_LIST_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 
@@ -113,6 +115,26 @@ describe("Statement of Capital controller tests", () => {
 
       // restore original function so it is no longer mocked
       spyGetUrlWithCompanyNumberTransactionIdAndSubmissionId.mockRestore();
+    });
+
+    it("Should create a new data block if Yes selected and current csSubmission has no data", async () => {
+      const submissionWithNoData: ConfirmationStatementSubmission = {
+        id: SUBMISSION_ID,
+        links: {
+          self: LINK_SELF
+        }
+      };
+      mockGetConfirmationStatement.mockResolvedValueOnce(submissionWithNoData);
+      const response = await request(app)
+        .post(STATEMENT_OF_CAPITAL_URL)
+        .send({ statementOfCapital: "yes" });
+
+      expect(response.status).toEqual(302);
+      expect(response.header.location).toEqual(TASK_LIST_URL);
+      const csSubmission: ConfirmationStatementSubmission = mockUpdateConfirmationStatement.mock.calls[0][3];
+      expect(csSubmission.id).toBe(SUBMISSION_ID);
+      expect(csSubmission.links.self).toBe(LINK_SELF);
+      expect(csSubmission.data?.statementOfCapitalData?.sectionStatus).toBe(SectionStatus.CONFIRMED);
     });
   });
 });


### PR DESCRIPTION
…it is now optional in model)

On SOC screen, if user selects Yes, status confirmed and statementOfCapital details are added to mongo. If No is selected, status is set to not confirmed and statementOfCapital details are removed from mongo record.