### PR TITLE
NCS-554 Remove redundant code

### DIFF
--- a/views/includes/officers.html
+++ b/views/includes/officers.html
@@ -12,7 +12,7 @@
         classes: "govuk-tag--green"
       })}}
     </div>
-    <div style="display: flex" class="govuk-!-padding-1 govuk-summary-list">
+    <div style="display: flex" class="govuk-!-padding-1">
       <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Nationality</dt>

--- a/views/includes/shareholders.html
+++ b/views/includes/shareholders.html
@@ -3,7 +3,7 @@
     <p class="govuk-!-font-weight-bold govuk-!-margin-0">IRVING, Kyrie</p>
 
   </div>
-  <div style="display: flex" class="govuk-!-padding-1 govuk-summary-list">
+  <div style="display: flex" class="govuk-!-padding-1">
     <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
 
       <div class="govuk-summary-list__row">


### PR DESCRIPTION
Remove redundant code from the officers and shareholders page which was causing larger padding at the end of the row.