### PR TITLE
NCS-551 Fix ROA page broken urls and address display on errorMsg render.

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,7 @@ export const SHAREHOLDERS_ERROR = "Select yes if the active shareholders are cor
 
 export const sessionCookieConstants = {
   ACTIVE_OFFICER_DETAILS_KEY: "activeOfficerDetails",
+  REGISTERED_OFFICE_ADDRESS_KEY: "registeredOfficeAddress",
   STATEMENT_OF_CAPITAL_KEY: "statementOfCapital"
 };
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,3 +1,4 @@
+import { Request } from "express";
 import { urlParams } from "../types/page.urls";
 
 const getUrlWithCompanyNumber = (url: string, companyNumber: string): string =>
@@ -11,7 +12,23 @@ const getUrlWithCompanyNumberTransactionIdAndSubmissionId = (url: string, compan
   return url;
 };
 
+const getUrlToPath = (pathToPage: string, req: Request): string => {
+  return getUrlWithCompanyNumberTransactionIdAndSubmissionId(pathToPage,
+                                                             getCompanyNumberFromRequestParams(req),
+                                                             getTransactionIdFromRequestParams(req),
+                                                             getSubmissionIdFromRequestParams(req)
+  );
+};
+
+const getCompanyNumberFromRequestParams = (req: Request): string => req.params[urlParams.PARAM_COMPANY_NUMBER];
+const getTransactionIdFromRequestParams = (req: Request): string => req.params[urlParams.PARAM_TRANSACTION_ID];
+const getSubmissionIdFromRequestParams = (req: Request): string => req.params[urlParams.PARAM_SUBMISSION_ID];
+
 export const urlUtils = {
+  getCompanyNumberFromRequestParams,
+  getTransactionIdFromRequestParams,
+  getSubmissionIdFromRequestParams,
+  getUrlToPath,
   getUrlWithCompanyNumber,
   getUrlWithCompanyNumberTransactionIdAndSubmissionId
 };

--- a/test/controllers/tasks/registered.office.address.controller.unit.ts
+++ b/test/controllers/tasks/registered.office.address.controller.unit.ts
@@ -42,14 +42,14 @@ describe("Registered Office Address controller tests", () => {
   });
 
   it("Should redirect to an error page when error is thrown", async () => {
-    const spyGetUrlWithCompanyNumber = jest.spyOn(urlUtils, "getUrlWithCompanyNumber");
-    spyGetUrlWithCompanyNumber.mockImplementationOnce(() => { throw new Error(); });
+    const spyGetUrlToPath = jest.spyOn(urlUtils, "getUrlToPath");
+    spyGetUrlToPath.mockImplementationOnce(() => { throw new Error(); });
     const response = await request(app).get(REGISTERED_OFFICE_ADDRESS_URL);
 
     expect(response.text).toContain("Sorry, the service is unavailable");
 
     // restore original function so it is no longer mocked
-    spyGetUrlWithCompanyNumber.mockRestore();
+    spyGetUrlToPath.mockRestore();
   });
 
   it("Should return to task list page when roa is confirmed", async () => {
@@ -76,14 +76,14 @@ describe("Registered Office Address controller tests", () => {
   });
 
   it("Should return an error page if error is thrown in post function", async () => {
-    const spyGetUrlWithCompanyNumber = jest.spyOn(urlUtils, "getUrlWithCompanyNumber");
-    spyGetUrlWithCompanyNumber.mockImplementationOnce(() => { throw new Error(); });
+    const spyGetUrlToPath = jest.spyOn(urlUtils, "getUrlToPath");
+    spyGetUrlToPath.mockImplementationOnce(() => { throw new Error(); });
     const response = await request(app).post(REGISTERED_OFFICE_ADDRESS_URL);
 
     expect(response.text).toContain("Sorry, the service is unavailable");
 
     // restore original function so it is no longer mocked
-    spyGetUrlWithCompanyNumber.mockRestore();
+    spyGetUrlToPath.mockRestore();
   });
 
 });

--- a/test/utils/url.unit.ts
+++ b/test/utils/url.unit.ts
@@ -1,10 +1,23 @@
+import { request } from "express";
 import { urlParams } from "../../src/types/page.urls";
 import { urlUtils } from "../../src/utils/url";
 
 describe("url utils tests", () => {
+  const COMPANY_NUMBER = "12345678";
+  const TX_ID = "987654321";
+  const SUB_ID = "1234-abcd";
+  const urlWithParams = `/something/:${urlParams.PARAM_COMPANY_NUMBER}/something/transaction/:${urlParams.PARAM_TRANSACTION_ID}/submission/:${urlParams.PARAM_SUBMISSION_ID}/andThenSome`;
+  const req = request;
+
+  beforeEach(() => {
+    req["params"] = {
+      [urlParams.PARAM_COMPANY_NUMBER]: COMPANY_NUMBER,
+      [urlParams.PARAM_TRANSACTION_ID]: TX_ID,
+      [urlParams.PARAM_SUBMISSION_ID]: SUB_ID
+    };
+  });
 
   describe("getUrlWithCompanyNumber tests", () => {
-    const COMPANY_NUMBER = "12345678";
 
     it("should populate a url with a company number", () => {
       const url = `/something/:${urlParams.PARAM_COMPANY_NUMBER}/something`;
@@ -12,4 +25,41 @@ describe("url utils tests", () => {
       expect(populatedUrl).toEqual(`/something/${COMPANY_NUMBER}/something`);
     });
   });
+
+  describe("getUrlToPath tests", () => {
+
+    it("Should populate the Url with the company number, transaction ID and submission ID from the request params", () => {
+      const populatedUrl = urlUtils.getUrlToPath(urlWithParams, req);
+      expect(populatedUrl).toEqual(`/something/${COMPANY_NUMBER}/something/transaction/${TX_ID}/submission/${SUB_ID}/andThenSome`);
+    });
+
+  });
+
+  describe("getUrlWithCompanyNumberTransactionIdAndSubmissionId tests", () => {
+
+    it("Should the Url with the company number, transaction ID and submission ID", () => {
+      const populatedUrl = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(urlWithParams, COMPANY_NUMBER, TX_ID, SUB_ID);
+      expect(populatedUrl).toEqual(`/something/${COMPANY_NUMBER}/something/transaction/${TX_ID}/submission/${SUB_ID}/andThenSome`);
+    });
+  });
+
+  describe("Request param tests", () => {
+
+    it("Should get the company number from the Url", () => {
+      const companyNumber = urlUtils.getCompanyNumberFromRequestParams(req);
+      expect(companyNumber).toEqual(COMPANY_NUMBER);
+    });
+
+    it("Should get the transaction ID from the Url", () => {
+      const txId = urlUtils.getTransactionIdFromRequestParams(req);
+      expect(txId).toEqual(TX_ID);
+    });
+
+    it("Should get the subscriptionn ID from the Url", () => {
+      const subId = urlUtils.getSubmissionIdFromRequestParams(req);
+      expect(subId).toEqual(SUB_ID);
+    });
+  });
+
+
 });


### PR DESCRIPTION
Also, moved repeated URL-related functions that are repeated across multiple task pages to the _**utils/url.ts**_.