### PR TITLE
NCS-135 Update private sdk to contain rle fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5695,8 +5695,8 @@
       }
     },
     "private-api-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#53458bf182876d6981c4b690fca5d34d014ab538",
-      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.43",
+      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#b63701eec8cf81f25557cd441d7208d054f293a9",
+      "from": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.44",
       "requires": {
         "@companieshouse/api-sdk-node": "^1.0.26",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "luxon": "^1.27.0",
     "nunjucks": "^3.2.3",
     "on-headers": "^1.0.2",
-    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.43",
+    "private-api-sdk-node": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#0.1.44",
     "safe-buffer": "^5.2.1",
     "yargs": "^15.3.1"
   },


### PR DESCRIPTION
RLE fields not present in version 1.43 so updated to 1.44