### PR TITLE
NCS-178 Adding psc statement value to cookie to redisplay on error page

### DIFF
--- a/src/controllers/tasks/psc.statement.controller.ts
+++ b/src/controllers/tasks/psc.statement.controller.ts
@@ -1,5 +1,9 @@
 import { NextFunction, Request, Response } from "express";
-import { PSC_STATEMENT_CONTROL_ERROR, PSC_STATEMENT_NOT_FOUND, RADIO_BUTTON_VALUE } from "../../utils/constants";
+import {
+  PSC_STATEMENT_CONTROL_ERROR,
+  PSC_STATEMENT_NOT_FOUND,
+  RADIO_BUTTON_VALUE,
+  sessionCookieConstants } from "../../utils/constants";
 import { PEOPLE_WITH_SIGNIFICANT_CONTROL_PATH, PSC_STATEMENT_PATH } from "../../types/page.urls";
 import { Templates } from "../../types/template.paths";
 import { urlUtils } from "../../utils/url";
@@ -9,11 +13,12 @@ import { Session } from "@companieshouse/node-session-handler";
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
 
-    const pscStatementText = await getPscStatementText(req);
+    const pscStatement = await getPscStatementText(req);
+    req.sessionCookie[sessionCookieConstants.PSC_STATEMENT_KEY] = pscStatement;
 
     return res.render(Templates.PSC_STATEMENT, {
       backLinkUrl: urlUtils.getUrlToPath(PEOPLE_WITH_SIGNIFICANT_CONTROL_PATH, req),
-      pscStatement: pscStatementText,
+      pscStatement,
       templateName: Templates.PSC_STATEMENT,
     });
   } catch (e) {
@@ -34,15 +39,13 @@ export const post = (req: Request, res: Response, next: NextFunction) => {
       });
     }
 
-    if (!pscButtonValue) {
-      const pscStatement = PSC_STATEMENT_NOT_FOUND;
-      return res.render(Templates.PSC_STATEMENT, {
-        backLinkUrl: urlUtils.getUrlToPath(PEOPLE_WITH_SIGNIFICANT_CONTROL_PATH, req),
-        pscStatementControlErrorMsg: PSC_STATEMENT_CONTROL_ERROR,
-        pscStatement,
-        templateName: Templates.PSC_STATEMENT,
-      });
-    }
+    const pscStatement: string = req.sessionCookie[sessionCookieConstants.PSC_STATEMENT_KEY];
+    return res.render(Templates.PSC_STATEMENT, {
+      backLinkUrl: urlUtils.getUrlToPath(PEOPLE_WITH_SIGNIFICANT_CONTROL_PATH, req),
+      pscStatementControlErrorMsg: PSC_STATEMENT_CONTROL_ERROR,
+      pscStatement,
+      templateName: Templates.PSC_STATEMENT,
+    });
   } catch (e) {
     return next(e);
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,6 +13,7 @@ export const PSC_STATEMENT_NOT_FOUND = "No additional statements relating to PSC
 
 export const sessionCookieConstants = {
   ACTIVE_DIRECTOR_DETAILS_KEY: "activeDirectorDetails",
+  PSC_STATEMENT_KEY: "pscStatement",
   REGISTERED_OFFICE_ADDRESS_KEY: "registeredOfficeAddress",
   STATEMENT_OF_CAPITAL_KEY: "statementOfCapital"
 };


### PR DESCRIPTION
Adding the psc statement value to the cookie so that when we submit the page and there's an error, the psc statement can be retrieved to be displayed on the error page