### PR TITLE
NCS-611 Show psc name in statement

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,6 +13,7 @@ export const WRONG_DETAILS_UPDATE_PSC = "Update the people with significant cont
 export const WRONG_DETAILS_INCORRECT_PSC = "Incorrect people with significant control - File a confirmation statement";
 export const WRONG_DETAILS_UPDATE_DIRECTOR = "Update the director details";
 export const WRONG_DETAILS_UPDATE_OFFICERS = "Update officers - File a confirmation statement";
+export const PSC_STATEMENT_NAME_PLACEHOLDER = "{linked_psc_name}";
 
 
 export const sessionCookieConstants = {

--- a/test/mocks/person.of.significant.control.mock.ts
+++ b/test/mocks/person.of.significant.control.mock.ts
@@ -108,6 +108,6 @@ export const mockSingleActivePsc: CompanyPersonWithSignificantControlStatement =
     self: "self"
   },
   notifiedOn: "2020-05-03",
-  statement: "Active Psc Statement",
+  statement: "api-enumeration-key",
   linkedPscName: "Bob"
 };


### PR DESCRIPTION
Some psc statements have a name placeholder that needs to be replaced with the name provided in the mongo record for psc statement