### PR TITLE
NCS-468 Updating task list status after psc statement page

### DIFF
--- a/src/controllers/tasks/people.with.significant.control.controller.ts
+++ b/src/controllers/tasks/people.with.significant.control.controller.ts
@@ -75,10 +75,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       });
     }
 
-    const sectionStatus: SectionStatus = RADIO_BUTTON_VALUE.YES === pscButtonValue ?
-      SectionStatus.CONFIRMED : SectionStatus.RECENT_FILING;
-
-    await sendUpdate(req, SECTIONS.PSC, sectionStatus);
+    await sendUpdate(req, SECTIONS.PSC, SectionStatus.NOT_CONFIRMED);
     return res.redirect(getPscStatementUrl(req, true));
   } catch (e) {
     return next(e);

--- a/src/controllers/tasks/statement.of.capital.controller.ts
+++ b/src/controllers/tasks/statement.of.capital.controller.ts
@@ -45,7 +45,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       const statementOfCapital: StatementOfCapital = req.sessionCookie[sessionCookieConstants.STATEMENT_OF_CAPITAL_KEY];
       await sendUpdate(req, SECTIONS.SOC, SectionStatus.CONFIRMED, statementOfCapital);
       return res.redirect(urlUtils
-        .getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, companyNumber, transactionId, submissionId),);
+        .getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, companyNumber, transactionId, submissionId));
     } else if (statementOfCapitalButtonValue === RADIO_BUTTON_VALUE.NO) {
       await sendUpdate(req, SECTIONS.SOC, SectionStatus.NOT_CONFIRMED);
       return res.render(Templates.WRONG_STATEMENT_OF_CAPITAL, {

--- a/test/controllers/tasks/people.with.significant.control.controller.unit.ts
+++ b/test/controllers/tasks/people.with.significant.control.controller.unit.ts
@@ -44,6 +44,11 @@ const APPOINTMENT_TYPE_5008 = "5008";
 const DOB_MONTH = 3;
 const DOB_YEAR = 1955;
 const FORMATTED_DATE = "March 1955";
+const FORENAME = "BOB";
+const FORENAME_TITLE_CASE = "Bob";
+const SURNAME = "WILSON";
+const ADDRESS_LINE_1 = "ADD LINE 1";
+const ADDRESS_LINE_1_TITLE_CASE = "Add Line 1";
 
 const mockSendUpdate = sendUpdate as jest.Mock;
 
@@ -52,10 +57,17 @@ mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next(
 
 const mockGetPscs = getPscs as jest.Mock;
 mockGetPscs.mockResolvedValue([{
+  address: {
+    addressLine1: ADDRESS_LINE_1
+  },
   appointmentType: APPOINTMENT_TYPE_5007,
   dateOfBirth: {
     month: DOB_MONTH,
     year: DOB_YEAR
+  },
+  nameElements: {
+    forename: FORENAME,
+    surname: SURNAME
   }
 }]);
 
@@ -75,7 +87,7 @@ describe("People with significant control controller tests", () => {
     mockSendUpdate.mockClear();
   });
 
-  describe("get tests", function () {
+  describe("get tests", () => {
     it("should navigate to the active pscs page", async () => {
       const response = await request(app).get(PEOPLE_WITH_SIGNIFICANT_CONTROL_URL);
       expect(response.text).toContain(PAGE_HEADING);
@@ -84,6 +96,9 @@ describe("People with significant control controller tests", () => {
       expect(toReadableFormatMonthYear).toBeCalledTimes(1);
       expect(mockToReadableFormatMonthYear.mock.calls[0][0]).toBe(DOB_MONTH);
       expect(mockToReadableFormatMonthYear.mock.calls[0][1]).toBe(DOB_YEAR);
+      expect(response.text).toContain(ADDRESS_LINE_1_TITLE_CASE);
+      expect(response.text).toContain(FORENAME_TITLE_CASE);
+      expect(response.text).toContain(SURNAME);
     });
 
     it("Should navigate to an error page if the function throws an error", async () => {
@@ -278,7 +293,7 @@ describe("People with significant control controller tests", () => {
         .send({ pscRadioValue: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.NOT_CONFIRMED);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(pscStatementPathWithIsPscParam("true"));
     });
@@ -289,7 +304,7 @@ describe("People with significant control controller tests", () => {
         .send({ pscRadioValue: RADIO_BUTTON_VALUE.RECENTLY_FILED });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.NOT_CONFIRMED);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(pscStatementPathWithIsPscParam("true"));
     });

--- a/test/controllers/tasks/statement.of.capital.controller.unit.ts
+++ b/test/controllers/tasks/statement.of.capital.controller.unit.ts
@@ -32,7 +32,6 @@ const STOP_PAGE_HEADING = "You cannot use this service - File a confirmation sta
 const COMPANY_NUMBER = "12345678";
 const SUBMISSION_ID = "a80f09e2";
 const TRANSACTION_ID = "111-111-111";
-const LINK_SELF = "/something";
 const STATEMENT_OF_CAPITAL_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(STATEMENT_OF_CAPITAL_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 const TASK_LIST_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 

--- a/views/includes/task-list/people.html
+++ b/views/includes/task-list/people.html
@@ -22,9 +22,9 @@
                     People with significant control (PSC)
                 </a>
             </span>
-        {% if taskList.peopleSignificantControl.state === "CHECKED" %}
+        {% if taskList.tasks.peopleSignificantControl.state === "CHECKED" %}
             {{ showChecked | safe | replace("statusIdPlaceholder", "pscStatus")}}
-        {% elseif taskList.peopleSignificantControl.state === "IN_PROGRESS" %}
+        {% elseif taskList.tasks.peopleSignificantControl.state === "IN_PROGRESS" %}
             {{ showInProgress | safe | replace("statusIdPlaceholder", "pscStatus")}}
         {% else %}
             {{ showNotChecked | safe | replace("statusIdPlaceholder", "pscStatus")}}


### PR DESCRIPTION
Updating psc details page so that 'yes' and 'recent filing' filing buttons map to status of 'IN PROGRESS' (as psc statement is now the final page)

Making psc statement page retun to task list page with correct task list status.