### PR TITLE
NCS-325 show full dob psc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5695,8 +5695,8 @@
       }
     },
     "private-api-sdk-node": {
-      "version": "git+ssh://git@github.com/companieshouse/private-api-sdk-node.git#6666a09d1b0257183b2e304ae38445d5156586a7",
-      "from": "private-api-sdk-node@github:companieshouse/private-api-sdk-node#0.1.50",
+      "version": "github:companieshouse/private-api-sdk-node#4162195a62c16e8c59584066b986f50f4639aca7",
+      "from": "github:companieshouse/private-api-sdk-node#ncs-325-add-psc-dob-iso",
       "requires": {
         "@companieshouse/api-sdk-node": "^1.0.26",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "luxon": "^1.27.0",
     "nunjucks": "^3.2.3",
     "on-headers": "^1.0.2",
-    "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#0.1.50",
+    "private-api-sdk-node": "github:companieshouse/private-api-sdk-node#ncs-325-add-psc-dob-iso",
     "safe-buffer": "^5.2.1",
     "yargs": "^15.3.1"
   },

--- a/src/controllers/tasks/people.with.significant.control.controller.ts
+++ b/src/controllers/tasks/people.with.significant.control.controller.ts
@@ -17,7 +17,7 @@ import {
 import { Session } from "@companieshouse/node-session-handler";
 import { getPscs } from "../../services/psc.service";
 import { createAndLogError, logger } from "../../utils/logger";
-import { toReadableFormatMonthYear } from "../../utils/date";
+import { toReadableFormat } from "../../utils/date";
 import { formatTitleCase } from "../../utils/format";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 
@@ -109,8 +109,8 @@ const handleDateOfBirth = (pscAppointmentType: string, psc: PersonOfSignificantC
   if (pscAppointmentType === appointmentTypeNames.RLE) {
     return "";
   }
-  if (psc.dateOfBirth?.month && psc.dateOfBirth.year) {
-    return toReadableFormatMonthYear(psc.dateOfBirth.month, psc.dateOfBirth.year);
+  if (psc.dateOfBirthIso) {
+    return toReadableFormat(psc.dateOfBirthIso);
   }
   throw createAndLogError(`Date of birth missing for individual psc name ${psc.nameElements?.forename} ${psc.nameElements?.surname}`);
 };

--- a/test/controllers/tasks/people.with.significant.control.controller.unit.ts
+++ b/test/controllers/tasks/people.with.significant.control.controller.unit.ts
@@ -43,7 +43,7 @@ const APPOINTMENT_TYPE_5007 = "5007";
 const APPOINTMENT_TYPE_5008 = "5008";
 const DOB_MONTH = 3;
 const DOB_YEAR = 1955;
-const FORMATTED_DATE = "March 1955";
+const FORMATTED_DOB = "21 March 1955";
 const DOB_ISO = "1955-03-21";
 const FORENAME = "BOB";
 const FORENAME_TITLE_CASE = "Bob";
@@ -74,7 +74,7 @@ mockGetPscs.mockResolvedValue([{
 } as PersonOfSignificantControl ]);
 
 const mockToReadableFormat = toReadableFormat as jest.Mock;
-mockToReadableFormat.mockReturnValue(FORMATTED_DATE);
+mockToReadableFormat.mockReturnValue(FORMATTED_DOB);
 
 const mockCreateAndLogError = createAndLogError as jest.Mock;
 mockCreateAndLogError.mockReturnValue(new Error());
@@ -100,6 +100,7 @@ describe("People with significant control controller tests", () => {
       expect(response.text).toContain(ADDRESS_LINE_1_TITLE_CASE);
       expect(response.text).toContain(FORENAME_TITLE_CASE);
       expect(response.text).toContain(SURNAME);
+      expect(response.text).toContain(FORMATTED_DOB);
     });
 
     it("Should navigate to an error page if the function throws an error", async () => {
@@ -130,7 +131,7 @@ describe("People with significant control controller tests", () => {
       const response = await request(app).get(PEOPLE_WITH_SIGNIFICANT_CONTROL_URL);
       expect(response.statusCode).toBe(200);
       expect(response.text).toContain("1 individual person");
-      expect(response.text).toContain(FORMATTED_DATE);
+      expect(response.text).toContain(FORMATTED_DOB);
     });
 
     it("should navigate to rle page if psc is rle type", async () => {
@@ -274,7 +275,7 @@ describe("People with significant control controller tests", () => {
       expect(response.text).toContain(PEOPLE_WITH_SIGNIFICANT_CONTROL_ERROR);
       expect(response.text).toContain(PAGE_HEADING);
       expect(response.text).toContain("1 individual person");
-      expect(response.text).toContain(FORMATTED_DATE);
+      expect(response.text).toContain(FORMATTED_DOB);
     });
 
     it("Should display wrong psc data page when no radio button is selected", async () => {

--- a/test/controllers/tasks/people.with.significant.control.controller.unit.ts
+++ b/test/controllers/tasks/people.with.significant.control.controller.unit.ts
@@ -12,10 +12,10 @@ import { companyAuthenticationMiddleware } from "../../../src/middleware/company
 import { PEOPLE_WITH_SIGNIFICANT_CONTROL_ERROR, RADIO_BUTTON_VALUE, SECTIONS } from "../../../src/utils/constants";
 import { sendUpdate } from "../../../src/utils/update.confirmation.statement.submission";
 import { getPscs } from "../../../src/services/psc.service";
-import { toReadableFormatMonthYear } from "../../../src/utils/date";
+import { toReadableFormat } from "../../../src/utils/date";
 import { urlUtils } from "../../../src/utils/url";
 import { createAndLogError } from "../../../src/utils/logger";
-import { SectionStatus } from "private-api-sdk-node/dist/services/confirmation-statement";
+import { PersonOfSignificantControl, SectionStatus } from "private-api-sdk-node/dist/services/confirmation-statement";
 
 const PAGE_TITLE = "Review the people with significant control";
 const PAGE_HEADING = "Check the people with significant control (PSC)";
@@ -44,6 +44,7 @@ const APPOINTMENT_TYPE_5008 = "5008";
 const DOB_MONTH = 3;
 const DOB_YEAR = 1955;
 const FORMATTED_DATE = "March 1955";
+const DOB_ISO = "1955-03-21";
 const FORENAME = "BOB";
 const FORENAME_TITLE_CASE = "Bob";
 const SURNAME = "WILSON";
@@ -65,14 +66,15 @@ mockGetPscs.mockResolvedValue([{
     month: DOB_MONTH,
     year: DOB_YEAR
   },
+  dateOfBirthIso: DOB_ISO,
   nameElements: {
     forename: FORENAME,
     surname: SURNAME
   }
-}]);
+} as PersonOfSignificantControl ]);
 
-const mockToReadableFormatMonthYear = toReadableFormatMonthYear as jest.Mock;
-mockToReadableFormatMonthYear.mockReturnValue(FORMATTED_DATE);
+const mockToReadableFormat = toReadableFormat as jest.Mock;
+mockToReadableFormat.mockReturnValue(FORMATTED_DATE);
 
 const mockCreateAndLogError = createAndLogError as jest.Mock;
 mockCreateAndLogError.mockReturnValue(new Error());
@@ -82,7 +84,7 @@ describe("People with significant control controller tests", () => {
   beforeEach(() => {
     mocks.mockAuthenticationMiddleware.mockClear();
     mockGetPscs.mockClear();
-    mockToReadableFormatMonthYear.mockClear();
+    mockToReadableFormat.mockClear();
     mockCreateAndLogError.mockClear();
     mockSendUpdate.mockClear();
   });
@@ -93,9 +95,8 @@ describe("People with significant control controller tests", () => {
       expect(response.text).toContain(PAGE_HEADING);
       expect(mockGetPscs).toBeCalledTimes(1);
       expect(mockGetPscs.mock.calls[0][1]).toBe(COMPANY_NUMBER);
-      expect(toReadableFormatMonthYear).toBeCalledTimes(1);
-      expect(mockToReadableFormatMonthYear.mock.calls[0][0]).toBe(DOB_MONTH);
-      expect(mockToReadableFormatMonthYear.mock.calls[0][1]).toBe(DOB_YEAR);
+      expect(mockToReadableFormat).toBeCalledTimes(1);
+      expect(mockToReadableFormat.mock.calls[0][0]).toBe(DOB_ISO);
       expect(response.text).toContain(ADDRESS_LINE_1_TITLE_CASE);
       expect(response.text).toContain(FORENAME_TITLE_CASE);
       expect(response.text).toContain(SURNAME);


### PR DESCRIPTION
Updating psc web controller to use the new dateOfBirthIso field on the psc data returned from the sdk in order to show the full DOB on the psc details screen.