### PR TITLE
NCS-641 add PUT functionality to transaction service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.49",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.49.tgz",
-      "integrity": "sha512-xVrHVrLy6EzOWSqTG501sZtYraMQ6RYKT8VmfzNDHMPGdn5FGQ6wt55orn799exKjOXFFmNG7CKmLLc5McgzhQ==",
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.50.tgz",
+      "integrity": "sha512-rTdfLZPguWl1SPVSIdqHbip50Xu9t+I7ST6QA06lJk05hlMW9vpIokzwMzHYNf1Dys+gy9jenZSTkmyDYZjEsQ==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/companieshouse/confirmation-statement-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.49",
+    "@companieshouse/api-sdk-node": "^1.0.50",
     "@companieshouse/node-session-handler": "^4.1.6",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/web-security-node": "^2.0.0",

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -4,7 +4,8 @@ import { createAndLogError, logger } from "../utils/logger";
 import { createPublicOAuthApiClient } from "./api.service";
 import { Session } from "@companieshouse/node-session-handler";
 import ApiClient from "@companieshouse/api-sdk-node/dist/client";
-import { ApiErrorResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { ApiErrorResponse, ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { DESCRIPTION, headers, REFERENCE, transactionStatus } from "../utils/constants";
 
 
 export const postTransaction = async (session: Session, companyNumber: string, description: string, reference: string) => {
@@ -20,7 +21,7 @@ export const postTransaction = async (session: Session, companyNumber: string, d
   const sdkResponse: Resource<Transaction> | ApiErrorResponse = await apiClient.transaction.postTransaction(transaction);
 
   if (!sdkResponse) {
-    throw createAndLogError(`Transaction API returned no response for company number ${companyNumber}`);
+    throw createAndLogError(`Transaction API POST request returned no response for company number ${companyNumber}`);
   }
 
   if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= 400) {
@@ -30,10 +31,59 @@ export const postTransaction = async (session: Session, companyNumber: string, d
   const castedSdkResponse: Resource<Transaction> = sdkResponse as Resource<Transaction>;
 
   if (!castedSdkResponse.resource) {
-    throw createAndLogError(`Transaction API returned no resource for company number ${companyNumber}`);
+    throw createAndLogError(`Transaction API POST request returned no resource for company number ${companyNumber}`);
   }
 
   logger.debug(`Received transaction ${JSON.stringify(sdkResponse)}`);
 
   return castedSdkResponse.resource;
+};
+
+export const closeTransaction = async (session: Session, companyNumber: string, transactionId: string): Promise<string | undefined> => {
+  const apiResponse: ApiResponse<Transaction> = await putTransaction(session, companyNumber, transactionId, DESCRIPTION, REFERENCE, transactionStatus.CLOSED);
+  if (apiResponse?.headers) {
+    return apiResponse.headers[headers.PAYMENT_REQUIRED];
+  }
+  return undefined;
+};
+
+/**
+ * Response from PUT transaction can contain a URL in header if payment is needed
+ */
+export const putTransaction = async (session: Session,
+                                     companyNumber: string,
+                                     transactionId: string,
+                                     transactionDescription: string,
+                                     transactionReference: string,
+                                     transactionStatus: string): Promise<ApiResponse<Transaction>> => {
+  const apiClient: ApiClient = createPublicOAuthApiClient(session);
+
+  const transaction: Transaction = {
+    companyNumber,
+    description: transactionDescription,
+    id: transactionId,
+    reference: transactionReference,
+    status: transactionStatus
+  };
+
+  logger.debug(`Updating transaction id ${transactionId} with company number ${companyNumber}, status ${transactionStatus}`);
+  const sdkResponse: ApiResponse<Transaction> | ApiErrorResponse = await apiClient.transaction.putTransaction(transaction);
+
+  if (!sdkResponse) {
+    throw createAndLogError(`Transaction API PUT request returned no response for transaction id ${transactionId}, company number ${companyNumber}`);
+  }
+
+  if (!sdkResponse.httpStatusCode || sdkResponse.httpStatusCode >= 400) {
+    throw createAndLogError(`Http status code ${sdkResponse.httpStatusCode} - Failed to put transaction for transaction id ${transactionId}, company number ${companyNumber}`);
+  }
+
+  const castedSdkResponse: ApiResponse<Transaction> = sdkResponse as ApiResponse<Transaction>;
+
+  if (!castedSdkResponse.resource) {
+    throw createAndLogError(`Transaction API PUT request returned no resource for transaction id ${transactionId}, company number ${companyNumber}`);
+  }
+
+  logger.debug(`Received transaction ${JSON.stringify(sdkResponse)}`);
+
+  return castedSdkResponse;
 };

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -8,7 +8,7 @@ import { ApiErrorResponse, ApiResponse } from "@companieshouse/api-sdk-node/dist
 import { DESCRIPTION, headers, REFERENCE, transactionStatus } from "../utils/constants";
 
 
-export const postTransaction = async (session: Session, companyNumber: string, description: string, reference: string) => {
+export const postTransaction = async (session: Session, companyNumber: string, description: string, reference: string): Promise<Transaction> => {
   const apiClient: ApiClient = createPublicOAuthApiClient(session);
 
   const transaction: Transaction = {

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -39,6 +39,9 @@ export const postTransaction = async (session: Session, companyNumber: string, d
   return castedSdkResponse.resource;
 };
 
+/**
+ * Response can contain a URL to start payment session if payment is needed
+ */
 export const closeTransaction = async (session: Session, companyNumber: string, transactionId: string): Promise<string | undefined> => {
   const apiResponse: ApiResponse<Transaction> = await putTransaction(session, companyNumber, transactionId, DESCRIPTION, REFERENCE, transactionStatus.CLOSED);
   if (apiResponse?.headers) {
@@ -48,7 +51,7 @@ export const closeTransaction = async (session: Session, companyNumber: string, 
 };
 
 /**
- * Response from PUT transaction can contain a URL in header if payment is needed
+ * Response from PUT transaction can contain a URL in header to start payment session if payment is needed
  */
 export const putTransaction = async (session: Session,
                                      companyNumber: string,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,3 +51,11 @@ export enum SECTIONS {
   SIC = "sicCodeData",
   SOC = "statementOfCapitalData"
 }
+
+export const transactionStatus = {
+  CLOSED: "closed"
+};
+
+export const headers = {
+  PAYMENT_REQUIRED: "X-Payment-Required"
+};

--- a/test/services/transaction.service.unit.ts
+++ b/test/services/transaction.service.unit.ts
@@ -4,7 +4,7 @@ jest.mock("../../src/utils/logger");
 
 import { Session } from "@companieshouse/node-session-handler";
 import { createPublicOAuthApiClient } from "../../src/services/api.service";
-import { postTransaction } from "../../src/services/transaction.service";
+import { closeTransaction, postTransaction } from "../../src/services/transaction.service";
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { createAndLogError } from "../../src/utils/logger";
 
@@ -62,7 +62,7 @@ describe ("transaction service tests", () => {
     });
   });
 
-  it ("Should throw an error when transaction api returns no resource", () => {
+  it.only ("Should throw an error when transaction api returns no resource", async () => {
     mockPostTransaction.mockReturnValue({
       httpStatusCode: 200
     });
@@ -70,5 +70,8 @@ describe ("transaction service tests", () => {
     postTransaction(session, "12345678", "desc", "ref").then(() => {fail();}).catch(() => {
       expect(mockCreateAndLogError).toBeCalledWith("Transaction API returned no resource for company number 12345678");
     });
+
+    const resp = await closeTransaction(session, "1234", "333");
+    console.log("**************" + resp);
   });
 });

--- a/test/services/transaction.service.unit.ts
+++ b/test/services/transaction.service.unit.ts
@@ -4,74 +4,103 @@ jest.mock("../../src/utils/logger");
 
 import { Session } from "@companieshouse/node-session-handler";
 import { createPublicOAuthApiClient } from "../../src/services/api.service";
-import { closeTransaction, postTransaction } from "../../src/services/transaction.service";
+import { postTransaction, putTransaction } from "../../src/services/transaction.service";
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { createAndLogError } from "../../src/utils/logger";
+import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
 
 const mockCreatePublicOAuthApiClient = createPublicOAuthApiClient as jest.Mock;
 const mockPostTransaction = jest.fn();
+const mockPutTransaction = jest.fn();
 const mockCreateAndLogError = createAndLogError as jest.Mock;
 
 mockCreatePublicOAuthApiClient.mockReturnValue({
   transaction: {
-    postTransaction: mockPostTransaction
+    postTransaction: mockPostTransaction,
+    putTransaction: mockPutTransaction
   }
 });
 
-let session;
+let session: any;
 
 
-describe ("transaction service tests", () => {
+describe("transaction service tests", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
     session = new Session;
   });
 
-  it ("Should successfully post a transaction", async() => {
-    mockPostTransaction.mockReturnValue({
-      httpStatusCode: 200,
-      resource: {
-        reference: "ref",
-        companyNumber: "12345678",
-        description: "desc"
-      }
-    });
-    const transaction: Transaction = await postTransaction(session, "12345678", "desc", "ref");
+  describe("postTransaction tests", () => {
+    it("Should successfully post a transaction", async() => {
+      mockPostTransaction.mockResolvedValueOnce({
+        httpStatusCode: 200,
+        resource: {
+          reference: "ref",
+          companyNumber: "12345678",
+          description: "desc"
+        }
+      });
+      const transaction: Transaction = await postTransaction(session, "12345678", "desc", "ref");
 
-    expect(transaction.reference).toEqual("ref");
-    expect(transaction.companyNumber).toEqual("12345678");
-    expect(transaction.description).toEqual("desc");
-  });
-
-  it ("Should throw an error when no transaction api response", () => {
-    mockPostTransaction.mockReturnValue(undefined);
-
-    postTransaction(session, "12345678", "desc", "ref").then(() => {fail();}).catch(() => {
-      expect(mockCreateAndLogError).toBeCalledWith("Transaction API returned no response for company number 12345678");
-    });
-  });
-
-  it ("Should throw an error when transaction api returns a status greater than 400", () => {
-    mockPostTransaction.mockReturnValue({
-      httpStatusCode: 404
+      expect(transaction.reference).toEqual("ref");
+      expect(transaction.companyNumber).toEqual("12345678");
+      expect(transaction.description).toEqual("desc");
     });
 
-    postTransaction(session, "12345678", "desc", "ref").then(() => {fail();}).catch(() => {
+    it("Should throw an error when no transaction api response", async () => {
+      mockPostTransaction.mockResolvedValueOnce(undefined);
+      const error: Error = new Error("oops");
+      mockCreateAndLogError.mockReturnValueOnce(error);
+
+      await expect(postTransaction(session, "12345678", "desc", "ref")).rejects.toThrow(error);
+      expect(mockCreateAndLogError).toBeCalledWith("Transaction API POST request returned no response for company number 12345678");
+    });
+
+    it("Should throw an error when transaction api returns a status greater than 400", async () => {
+      mockPostTransaction.mockReturnValue({
+        httpStatusCode: 404
+      });
+
+      const error: Error = new Error("oops");
+      mockCreateAndLogError.mockReturnValueOnce(error);
+
+      await expect(postTransaction(session, "12345678", "desc", "ref")).rejects.toThrow(error);
       expect(mockCreateAndLogError).toBeCalledWith("Http status code 404 - Failed to post transaction for company number 12345678");
     });
+
+    it("Should throw an error when transaction api returns no resource", async () => {
+      mockPostTransaction.mockReturnValue({
+        httpStatusCode: 200
+      });
+
+      const error: Error = new Error("oops");
+      mockCreateAndLogError.mockReturnValueOnce(error);
+
+      await expect(postTransaction(session, "12345678", "desc", "ref")).rejects.toThrow(error);
+      expect(mockCreateAndLogError).toBeCalledWith("Transaction API POST request returned no resource for company number 12345678");
+    });
   });
 
-  it.only ("Should throw an error when transaction api returns no resource", async () => {
-    mockPostTransaction.mockReturnValue({
-      httpStatusCode: 200
-    });
 
-    postTransaction(session, "12345678", "desc", "ref").then(() => {fail();}).catch(() => {
-      expect(mockCreateAndLogError).toBeCalledWith("Transaction API returned no resource for company number 12345678");
-    });
+  describe("putTransaction tests", () => {
+    it("Should successfully PUT a transaction", async () => {
+      mockPutTransaction.mockReturnValue({
+        headers: {
+          "X-Payment-Required": "http://payment"
+        },
+        httpStatusCode: 200,
+        resource: {
+          reference: "ref",
+          companyNumber: "12345678",
+          description: "desc"
+        }
+      } as ApiResponse<Transaction>);
+      const transaction: ApiResponse<Transaction> = await putTransaction(session, "12345678", "2222", "desc", "ref", "closed");
 
-    const resp = await closeTransaction(session, "1234", "333");
-    console.log("**************" + resp);
+      expect(transaction.resource?.reference).toEqual("ref");
+      expect(transaction.resource?.companyNumber).toEqual("12345678");
+      expect(transaction.resource?.description).toEqual("desc");
+    });
   });
 });


### PR DESCRIPTION
Updating the transaction.service to use the new PUT transaction functionality in the api-sdk-node.
Also added a function to handle closing a transaction.
Updated the transaction unit tests and fixed a few of the error checking ones which were passing with the expect failing.