### PR TITLE
NCS-641 Adding a reference when updating transaction

### DIFF
--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -42,8 +42,8 @@ export const postTransaction = async (session: Session, companyNumber: string, d
 /**
  * Response can contain a URL to start payment session if payment is needed
  */
-export const closeTransaction = async (session: Session, companyNumber: string, transactionId: string): Promise<string | undefined> => {
-  const apiResponse: ApiResponse<Transaction> = await putTransaction(session, companyNumber, transactionId, DESCRIPTION, REFERENCE, transactionStatuses.CLOSED);
+export const closeTransaction = async (session: Session, companyNumber: string, confirmationStatementId: string, transactionId: string): Promise<string | undefined> => {
+  const apiResponse: ApiResponse<Transaction> = await putTransaction(session, companyNumber, confirmationStatementId, transactionId, DESCRIPTION, transactionStatuses.CLOSED);
   return apiResponse.headers?.[headers.PAYMENT_REQUIRED];
 };
 
@@ -52,17 +52,18 @@ export const closeTransaction = async (session: Session, companyNumber: string, 
  */
 export const putTransaction = async (session: Session,
                                      companyNumber: string,
+                                     confirmationStatementId: string,
                                      transactionId: string,
                                      transactionDescription: string,
-                                     transactionReference: string,
                                      transactionStatus: string): Promise<ApiResponse<Transaction>> => {
   const apiClient: ApiClient = createPublicOAuthApiClient(session);
 
+  const csReference = `${REFERENCE}_${confirmationStatementId}`;
   const transaction: Transaction = {
     companyNumber,
     description: transactionDescription,
     id: transactionId,
-    reference: transactionReference,
+    reference: csReference,
     status: transactionStatus
   };
 

--- a/test/services/transaction.service.unit.ts
+++ b/test/services/transaction.service.unit.ts
@@ -8,6 +8,7 @@ import { closeTransaction, postTransaction, putTransaction } from "../../src/ser
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
 import { createAndLogError } from "../../src/utils/logger";
 import { ApiResponse } from "@companieshouse/api-sdk-node/dist/services/resource";
+import { REFERENCE } from "../../src/utils/constants";
 
 const mockCreatePublicOAuthApiClient = createPublicOAuthApiClient as jest.Mock;
 const mockPostTransaction = jest.fn();
@@ -27,6 +28,8 @@ mockCreateAndLogError.mockReturnValue(ERROR);
 let session: any;
 const TRANSACTION_ID = "2222";
 const COMPANY_NUMBER = "12345678";
+const CS_SUBMISSION_ID = "764347373";
+const EXPECTED_REF = REFERENCE + "_" + CS_SUBMISSION_ID;
 
 describe("transaction service tests", () => {
 
@@ -87,27 +90,28 @@ describe("transaction service tests", () => {
         },
         httpStatusCode: 200,
         resource: {
-          reference: "ref",
+          reference: EXPECTED_REF,
           companyNumber: COMPANY_NUMBER,
           description: "desc",
           status: "closed"
         }
       } as ApiResponse<Transaction>);
-      const transaction: ApiResponse<Transaction> = await putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "ref", "closed");
+      const transaction: ApiResponse<Transaction> = await putTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID, "desc", "closed");
 
-      expect(transaction.resource?.reference).toEqual("ref");
+      expect(transaction.resource?.reference).toEqual(EXPECTED_REF);
       expect(transaction.resource?.companyNumber).toEqual(COMPANY_NUMBER);
       expect(transaction.resource?.description).toEqual("desc");
       expect(transaction.resource?.status).toEqual("closed");
 
       expect(mockPutTransaction.mock.calls[0][0].status).toBe("closed");
       expect(mockPutTransaction.mock.calls[0][0].id).toBe(TRANSACTION_ID);
+      expect(mockPutTransaction.mock.calls[0][0].reference).toBe(EXPECTED_REF);
     });
 
     it("Should throw an error when no transaction api response", async () => {
       mockPutTransaction.mockResolvedValueOnce(undefined);
 
-      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "ref", "closed")).rejects.toThrow(ERROR);
+      await expect(putTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
       expect(mockCreateAndLogError).toBeCalledWith(`Transaction API PUT request returned no response for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
     });
 
@@ -116,7 +120,7 @@ describe("transaction service tests", () => {
         httpStatusCode: 404
       });
 
-      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "ref", "closed")).rejects.toThrow(ERROR);
+      await expect(putTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
       expect(mockCreateAndLogError).toBeCalledWith(`Http status code 404 - Failed to put transaction for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
     });
 
@@ -125,7 +129,7 @@ describe("transaction service tests", () => {
         httpStatusCode: 200
       });
 
-      await expect(putTransaction(session, COMPANY_NUMBER, TRANSACTION_ID, "desc", "ref", "closed")).rejects.toThrow(ERROR);
+      await expect(putTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
       expect(mockCreateAndLogError).toBeCalledWith(`Transaction API PUT request returned no resource for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
     });
   });
@@ -139,14 +143,14 @@ describe("transaction service tests", () => {
         },
         httpStatusCode: 200,
         resource: {
-          reference: "ref",
+          reference: EXPECTED_REF,
           companyNumber: COMPANY_NUMBER,
           description: "desc",
           status: "closed"
         }
       } as ApiResponse<Transaction>);
 
-      const url = await closeTransaction(session, COMPANY_NUMBER, TRANSACTION_ID);
+      const url = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
 
       expect(url).toBe(paymentUrl);
     });
@@ -156,14 +160,14 @@ describe("transaction service tests", () => {
         headers: {  },
         httpStatusCode: 200,
         resource: {
-          reference: "ref",
+          reference: EXPECTED_REF,
           companyNumber: COMPANY_NUMBER,
           description: "desc",
           status: "closed"
         }
       } as ApiResponse<Transaction>);
 
-      const url = await closeTransaction(session, COMPANY_NUMBER, TRANSACTION_ID);
+      const url = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
 
       expect(url).toBeUndefined();
     });
@@ -172,14 +176,14 @@ describe("transaction service tests", () => {
       mockPutTransaction.mockResolvedValueOnce({
         httpStatusCode: 200,
         resource: {
-          reference: "ref",
+          reference: EXPECTED_REF,
           companyNumber: COMPANY_NUMBER,
           description: "desc",
           status: "closed"
         }
       } as ApiResponse<Transaction>);
 
-      const url = await closeTransaction(session, COMPANY_NUMBER, TRANSACTION_ID);
+      const url = await closeTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID);
 
       expect(url).toBeUndefined();
     });


### PR DESCRIPTION
adding a reference containing the confirmation statement id when using PUT to update transaction