### PR TITLE
NCS-642 Removing check for resource on transaction api PUT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "@companieshouse/api-sdk-node": {
-      "version": "1.0.50",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.50.tgz",
-      "integrity": "sha512-rTdfLZPguWl1SPVSIdqHbip50Xu9t+I7ST6QA06lJk05hlMW9vpIokzwMzHYNf1Dys+gy9jenZSTkmyDYZjEsQ==",
+      "version": "1.0.53",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-1.0.53.tgz",
+      "integrity": "sha512-1eAZTWskIf67Lyy5xokX+L7wmFG5AdCLnQN9PkkP1r/QAU8hsQypuw91FXsbw3cOoAGfNUpdqQT5E+vQUBg+FQ==",
       "requires": {
         "camelcase-keys": "~6.2.2",
         "request": "~2.88.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/companieshouse/confirmation-statement-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^1.0.50",
+    "@companieshouse/api-sdk-node": "^1.0.53",
     "@companieshouse/node-session-handler": "^4.1.6",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/web-security-node": "^2.0.0",

--- a/src/services/transaction.service.ts
+++ b/src/services/transaction.service.ts
@@ -105,10 +105,6 @@ export const putTransaction = async (session: Session,
 
   const castedSdkResponse: ApiResponse<Transaction> = sdkResponse as ApiResponse<Transaction>;
 
-  if (!castedSdkResponse.resource) {
-    throw createAndLogError(`Transaction API PUT request returned no resource for transaction id ${transactionId}, company number ${companyNumber}`);
-  }
-
   logger.debug(`Received transaction ${JSON.stringify(sdkResponse)}`);
 
   return castedSdkResponse;

--- a/test/services/transaction.service.unit.ts
+++ b/test/services/transaction.service.unit.ts
@@ -125,15 +125,6 @@ describe("transaction service tests", () => {
       await expect(putTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
       expect(mockCreateAndLogError).toBeCalledWith(`Http status code 404 - Failed to put transaction for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
     });
-
-    it("Should throw an error when transaction api returns no resource", async () => {
-      mockPutTransaction.mockResolvedValueOnce({
-        httpStatusCode: 200
-      });
-
-      await expect(putTransaction(session, COMPANY_NUMBER, CS_SUBMISSION_ID, TRANSACTION_ID, "desc", "closed")).rejects.toThrow(ERROR);
-      expect(mockCreateAndLogError).toBeCalledWith(`Transaction API PUT request returned no resource for transaction id ${TRANSACTION_ID}, company number ${COMPANY_NUMBER}`);
-    });
   });
 
   describe("closeTransaction tests", () => {


### PR DESCRIPTION
Transaction api PUT doesn't return a body so removing check for resource body