### PR TITLE
Fix address arrangement to march specified order in NCS-714

### DIFF
--- a/src/controllers/tasks/registered.office.address.controller.ts
+++ b/src/controllers/tasks/registered.office.address.controller.ts
@@ -2,21 +2,21 @@ import { NextFunction, Request, Response } from "express";
 import { urlUtils } from "../../utils/url";
 import { TASK_LIST_PATH, REGISTERED_OFFICE_ADDRESS_PATH, CHANGE_ROA_PATH } from "../../types/page.urls";
 import { Templates } from "../../types/template.paths";
-import { CompanyProfile, RegisteredOfficeAddress } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { getCompanyProfile } from "../../services/company.profile.service";
 import { RADIO_BUTTON_VALUE, REGISTERED_OFFICE_ADDRESS_ERROR, SECTIONS } from "../../utils/constants";
 import {
   SectionStatus
 } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
-import { formatTitleCase, formatAddressForDisplay } from "../../utils/format";
+import { formatAddressForDisplay, formatRegisteredOfficeAddress } from "../../utils/format";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const companyNumber = urlUtils.getCompanyNumberFromRequestParams(req);
     const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
     const backLinkUrl = urlUtils.getUrlToPath(TASK_LIST_PATH, req);
-    const registeredOfficeAddress = formatAddressForDisplay(formatAddress(companyProfile.registeredOfficeAddress));
+    const registeredOfficeAddress = formatAddressForDisplay(formatRegisteredOfficeAddress(companyProfile.registeredOfficeAddress));
     return res.render(Templates.REGISTERED_OFFICE_ADDRESS, {
       templateName: Templates.REGISTERED_OFFICE_ADDRESS,
       backLinkUrl,
@@ -47,7 +47,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
 
     const companyNumber = urlUtils.getCompanyNumberFromRequestParams(req);
     const companyProfile: CompanyProfile = await getCompanyProfile(companyNumber);
-    const registeredOfficeAddress = formatAddressForDisplay(formatAddress(companyProfile.registeredOfficeAddress));
+    const registeredOfficeAddress = formatAddressForDisplay(formatRegisteredOfficeAddress(companyProfile.registeredOfficeAddress));
     return res.render(Templates.REGISTERED_OFFICE_ADDRESS, {
       backLinkUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),
       roaErrorMsg: REGISTERED_OFFICE_ADDRESS_ERROR,
@@ -57,19 +57,4 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
   } catch (e) {
     return next(e);
   }
-};
-
-const formatAddress = (address: RegisteredOfficeAddress): RegisteredOfficeAddress => {
-  const addressClone: RegisteredOfficeAddress = JSON.parse(JSON.stringify(address));
-  return {
-    careOf: formatTitleCase(addressClone.careOf),
-    poBox: formatTitleCase(addressClone.poBox),
-    premises: formatTitleCase(addressClone.premises),
-    addressLineOne: formatTitleCase(addressClone.addressLineOne),
-    addressLineTwo: formatTitleCase(addressClone.addressLineTwo),
-    locality: formatTitleCase(addressClone.locality),
-    region: formatTitleCase(addressClone.region),
-    country: formatTitleCase(addressClone.country),
-    postalCode: addressClone.postalCode?.toUpperCase()
-  };
 };

--- a/src/controllers/tasks/registered.office.address.controller.ts
+++ b/src/controllers/tasks/registered.office.address.controller.ts
@@ -63,13 +63,13 @@ const formatAddress = (address: RegisteredOfficeAddress): RegisteredOfficeAddres
   const addressClone: RegisteredOfficeAddress = JSON.parse(JSON.stringify(address));
   return {
     careOf: formatTitleCase(addressClone.careOf),
+    poBox: formatTitleCase(addressClone.poBox),
+    premises: formatTitleCase(addressClone.premises),
     addressLineOne: formatTitleCase(addressClone.addressLineOne),
     addressLineTwo: formatTitleCase(addressClone.addressLineTwo),
-    poBox: formatTitleCase(addressClone.poBox),
     locality: formatTitleCase(addressClone.locality),
-    country: formatTitleCase(addressClone.country),
-    premises: formatTitleCase(addressClone.premises),
     region: formatTitleCase(addressClone.region),
+    country: formatTitleCase(addressClone.country),
     postalCode: addressClone.postalCode?.toUpperCase()
   };
 };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -39,13 +39,13 @@ export const formatAddress = (address: Address): Address => {
   const addressClone: Address = JSON.parse(JSON.stringify(address));
   return {
     careOf: formatTitleCase(addressClone.careOf),
+    poBox: formatTitleCase(addressClone.poBox),
+    premises: formatTitleCase(addressClone.premises),
     addressLine1: formatTitleCase(addressClone.addressLine1),
     addressLine2: formatTitleCase(addressClone.addressLine2),
-    poBox: formatTitleCase(addressClone.poBox),
     locality: formatTitleCase(addressClone.locality),
-    country: formatTitleCase(addressClone.country),
-    premises: formatTitleCase(addressClone.premises),
     region: formatTitleCase(addressClone.region),
+    country: formatTitleCase(addressClone.country),
     postalCode: addressClone.postalCode?.toUpperCase()
   };
 };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,4 @@
+import { RegisteredOfficeAddress } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { ActiveDirectorDetails, Address } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 
 export const formatTitleCase = (str: string|undefined): string =>  {
@@ -43,6 +44,21 @@ export const formatAddress = (address: Address): Address => {
     premises: formatTitleCase(addressClone.premises),
     addressLine1: formatTitleCase(addressClone.addressLine1),
     addressLine2: formatTitleCase(addressClone.addressLine2),
+    locality: formatTitleCase(addressClone.locality),
+    region: formatTitleCase(addressClone.region),
+    country: formatTitleCase(addressClone.country),
+    postalCode: addressClone.postalCode?.toUpperCase()
+  };
+};
+
+export const formatRegisteredOfficeAddress = (address: RegisteredOfficeAddress): RegisteredOfficeAddress => {
+  const addressClone: RegisteredOfficeAddress = JSON.parse(JSON.stringify(address));
+  return {
+    careOf: formatTitleCase(addressClone.careOf),
+    poBox: formatTitleCase(addressClone.poBox),
+    premises: formatTitleCase(addressClone.premises),
+    addressLineOne: formatTitleCase(addressClone.addressLineOne),
+    addressLineTwo: formatTitleCase(addressClone.addressLineTwo),
     locality: formatTitleCase(addressClone.locality),
     region: formatTitleCase(addressClone.region),
     country: formatTitleCase(addressClone.country),


### PR DESCRIPTION
The correct order of the address data to be displayed on web is;

> care_of
> po_box
> premises
> address_line_1
> address_line_2
> locality
> region
> country
> postal_code
