### PR TITLE
NCS-721 Align radio button for statement of capital

### DIFF
--- a/views/tasks/statement-of-capital.html
+++ b/views/tasks/statement-of-capital.html
@@ -71,7 +71,7 @@
                 errorMessage: statementOfCapitalError,
                 fieldset: {
                   legend: {
-                    text: "Is the statement of capital correct?",
+                    html: "Is the statement of capital correct?",
                     isPageHeading: false,
                     classes: "govuk-fieldset__legend--l"
                   }


### PR DESCRIPTION
[NCS-721
](https://companieshouse.atlassian.net/secure/RapidBoard.jspa?rapidView=234&modal=detail&selectedIssue=NCS-721)
Align radio button horizontally instead of vertically like in the prototype for statement of capital.