### PR TITLE
NCS-721 Vertically align the radio button

### DIFF
--- a/views/tasks/statement-of-capital.html
+++ b/views/tasks/statement-of-capital.html
@@ -65,7 +65,7 @@
 
             {% if sharesValidation and totalAmountUnpaidValidation %}
               {{ govukRadios({
-                classes: "govuk-radios--inline",
+                classes: "govuk-radios",
                 idPrefix: "statement-of-capital",
                 name: "statementOfCapital",
                 errorMessage: statementOfCapitalError,


### PR DESCRIPTION
[NCS-721
](https://companieshouse.atlassian.net/secure/RapidBoard.jspa?rapidView=234&projectKey=BI&modal=detail&selectedIssue=NCS-721)
Align the radio button on statement of capital page vertically instead of horizontally.