### PR TITLE
NCS-645 Save section status with more consistency

### DIFF
--- a/src/controllers/tasks/active.directors.controller.ts
+++ b/src/controllers/tasks/active.directors.controller.ts
@@ -43,7 +43,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     const companyNumber = urlUtils.getCompanyNumberFromRequestParams(req);
     const session: Session = req.session as Session;
     const activeDirectorDetailsBtnValue = req.body.activeDirectors;
-    if (activeDirectorDetailsBtnValue === RADIO_BUTTON_VALUE.YES) {
+    if (activeDirectorDetailsBtnValue === RADIO_BUTTON_VALUE.YES || activeDirectorDetailsBtnValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
       await sendUpdate(req, SECTIONS.ACTIVE_DIRECTOR, SectionStatus.CONFIRMED);
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     } else if (activeDirectorDetailsBtnValue === RADIO_BUTTON_VALUE.NO) {

--- a/src/controllers/tasks/people.with.significant.control.controller.ts
+++ b/src/controllers/tasks/people.with.significant.control.controller.ts
@@ -7,19 +7,16 @@ import {
   appointmentTypes,
   PEOPLE_WITH_SIGNIFICANT_CONTROL_ERROR,
   RADIO_BUTTON_VALUE,
-  SECTIONS,
   WRONG_DETAILS_INCORRECT_PSC,
   WRONG_DETAILS_UPDATE_PSC } from "../../utils/constants";
 import {
   PersonOfSignificantControl,
-  SectionStatus
 } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { Session } from "@companieshouse/node-session-handler";
 import { getPscs } from "../../services/psc.service";
 import { createAndLogError, logger } from "../../utils/logger";
 import { toReadableFormat } from "../../utils/date";
 import { formatPSCForDisplay, formatAddressForDisplay } from "../../utils/format";
-import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -69,7 +66,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     if (pscButtonValue === RADIO_BUTTON_VALUE.NO) {
-      await sendUpdate(req, SECTIONS.PSC, SectionStatus.NOT_CONFIRMED);
       return res.render(Templates.WRONG_DETAILS, {
         templateName: Templates.WRONG_DETAILS,
         backLinkUrl: urlUtils.getUrlToPath(PEOPLE_WITH_SIGNIFICANT_CONTROL_PATH, req),
@@ -79,7 +75,6 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       });
     }
 
-    await sendUpdate(req, SECTIONS.PSC, SectionStatus.NOT_CONFIRMED);
     return res.redirect(getPscStatementUrl(req, true));
   } catch (e) {
     return next(e);

--- a/src/controllers/tasks/psc.statement.controller.ts
+++ b/src/controllers/tasks/psc.statement.controller.ts
@@ -101,7 +101,7 @@ const getSectionStatusFromButtonValue = (radioButtonValue: RADIO_BUTTON_VALUE): 
   const buttonStatusMap = {
     [RADIO_BUTTON_VALUE.YES]: SectionStatus.CONFIRMED,
     [RADIO_BUTTON_VALUE.NO]: SectionStatus.NOT_CONFIRMED,
-    [RADIO_BUTTON_VALUE.RECENTLY_FILED]: SectionStatus.RECENT_FILING
+    [RADIO_BUTTON_VALUE.RECENTLY_FILED]: SectionStatus.CONFIRMED
   };
   return buttonStatusMap[radioButtonValue];
 };

--- a/src/controllers/tasks/registered.office.address.controller.ts
+++ b/src/controllers/tasks/registered.office.address.controller.ts
@@ -31,7 +31,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const roaButtonValue = req.body.registeredOfficeAddress;
 
-    if (roaButtonValue === RADIO_BUTTON_VALUE.YES) {
+    if (roaButtonValue === RADIO_BUTTON_VALUE.YES || roaButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
       await sendUpdate(req, SECTIONS.ROA, SectionStatus.CONFIRMED);
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }

--- a/test/controllers/tasks/active.directors.controller.unit.ts
+++ b/test/controllers/tasks/active.directors.controller.unit.ts
@@ -146,6 +146,17 @@ describe("Active directors controller tests", () => {
       expect(response.text).toContain(WRONG_OFFICER_PAGE_HEADING);
     });
 
+    it("Should redirect to task list when recently filed radio button is selected", async () => {
+      const response = await request(app)
+        .post(ACTIVE_DIRECTOR_DETAILS_URL)
+        .send({ activeDirectors: "recently_filed" });
+
+      expect(response.status).toEqual(302);
+      expect(response.header.location).toEqual(TASK_LIST_URL);
+      expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ACTIVE_DIRECTOR);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+    });
+
     it("Should redisplay active directors page with error when radio button is not selected", async () => {
       const response = await request(app).post(ACTIVE_DIRECTOR_DETAILS_URL);
       expect(response.status).toEqual(200);

--- a/test/controllers/tasks/psc.statement.controller.unit.ts
+++ b/test/controllers/tasks/psc.statement.controller.unit.ts
@@ -191,7 +191,7 @@ describe("PSC Statement controller tests", () => {
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
     });
 
     it("Should return an error page if error is thrown", async () => {

--- a/test/controllers/tasks/registered.office.address.controller.unit.ts
+++ b/test/controllers/tasks/registered.office.address.controller.unit.ts
@@ -77,6 +77,17 @@ describe("Registered Office Address controller tests", () => {
     expect(response.text).not.toContain(REGISTERED_OFFICE_ADDRESS_ERROR);
   });
 
+  it("Should redirect to task list when recently filed radio button is selected", async () => {
+    const response = await request(app)
+      .post(REGISTERED_OFFICE_ADDRESS_URL)
+      .send({ registeredOfficeAddress: "recently_filed" });
+
+    expect(response.status).toEqual(302);
+    expect(response.header.location).toEqual(TASK_LIST_URL);
+    expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ROA);
+    expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+  });
+
   it("Should redisplay roa page with error when radio button is not selected", async () => {
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     const response = await request(app).post(REGISTERED_OFFICE_ADDRESS_URL);


### PR DESCRIPTION
[NCS-645](https://companieshouse.atlassian.net/jira/software/c/projects/NCS/boards/234?modal=detail&selectedIssue=NCS-645)

Save section status relating to recently filled radio button as CONFIRMED instead of RECENT_FILING for all the tasks. Tasks that required changes were Officers, PSCs and ROA.

Also, only save section status for PSC statement page and not for PSC review page.