### PR TITLE
Add module name to payment service log messages

### DIFF
--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -32,11 +32,11 @@ export const startPaymentsSession = async (session: Session, paymentSessionUrl: 
 
   if (paymentResult.isFailure()) {
     const errorResponse = paymentResult.value;
-    logger.error(`${errorResponse?.httpStatusCode} - ${JSON.stringify(errorResponse?.errors)}`);
+    logger.error(`payment.service failure to create payment - http response status code = ${errorResponse?.httpStatusCode} - ${JSON.stringify(errorResponse?.errors)}`);
     if (errorResponse.httpStatusCode === 401 || errorResponse.httpStatusCode === 429) {
-      throw createAndLogError(`Http status code ${errorResponse.httpStatusCode} - Failed to create payment,  ${JSON.stringify(errorResponse?.errors) || "Unknown Error"}`);
+      throw createAndLogError(`payment.service Http status code ${errorResponse.httpStatusCode} - Failed to create payment,  ${JSON.stringify(errorResponse?.errors) || "Unknown Error"}`);
     } else {
-      throw createAndLogError(`Unknown Error ${JSON.stringify(errorResponse?.errors) || "No Errors found in response"}`);
+      throw createAndLogError(`payment.service Unknown Error ${JSON.stringify(errorResponse?.errors) || "No Errors found in response"}`);
     }
   } else {
     logger.info(`Create payment, status_code=${paymentResult.value.httpStatusCode}`);

--- a/test/services/payment.service.unit.ts
+++ b/test/services/payment.service.unit.ts
@@ -104,7 +104,7 @@ describe("Payment Service tests", () => {
         .rejects
         .toThrow(ERROR);
 
-      expect(mockCreateAndLogError).toBeCalledWith("Http status code 401 - Failed to create payment,  {\"error1\":\"something\"}");
+      expect(mockCreateAndLogError).toBeCalledWith("payment.service Http status code 401 - Failed to create payment,  {\"error1\":\"something\"}");
     });
 
     it("Should throw error on payment failure 429 response", async () => {
@@ -118,7 +118,7 @@ describe("Payment Service tests", () => {
         .rejects
         .toThrow(ERROR);
 
-      expect(mockCreateAndLogError).toBeCalledWith("Http status code 429 - Failed to create payment,  {\"error1\":\"something\"}");
+      expect(mockCreateAndLogError).toBeCalledWith("payment.service Http status code 429 - Failed to create payment,  {\"error1\":\"something\"}");
     });
 
     it("Should throw error on payment failure with unknown http response", async () => {
@@ -132,7 +132,7 @@ describe("Payment Service tests", () => {
         .rejects
         .toThrow(ERROR);
 
-      expect(mockCreateAndLogError).toBeCalledWith('Unknown Error {"error1":"something"}');
+      expect(mockCreateAndLogError).toBeCalledWith('payment.service Unknown Error {"error1":"something"}');
     });
   });
 });


### PR DESCRIPTION
Adding a bit more info to the payment service log messages to highlight where the error occurred after we had some issues in testing and logs had 
{"created":"2021-11-08T14:58:09.068+00:00","event":"error","namespace":"Confirmation Statement Web","data":{"message":"400 - {\"message\":\"failed to execute http request\"}"}}
{"created":"2021-11-08T14:58:09.068+00:00","event":"error","namespace":"Confirmation Statement Web","data":{"message":"Error: Unknown Error {\"message\":\"failed to execute http request\"}\n    at createAndLogError 
