### PR TITLE
BI-9484 Add template name to task list and trading

### DIFF
--- a/src/controllers/task.list.controller.ts
+++ b/src/controllers/task.list.controller.ts
@@ -32,7 +32,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
       backLinkUrl,
       company,
       taskList,
-      reviewUrl
+      reviewUrl,
+      templateName: Templates.TASK_LIST
     });
   } catch (e) {
     return next(e);

--- a/src/controllers/trading.status.controller.ts
+++ b/src/controllers/trading.status.controller.ts
@@ -8,7 +8,8 @@ import { sendTradingStatusUpdate } from "../utils/update.confirmation.statement.
 export const get = (req: Request, res: Response) => {
   const companyNumber: string = getCompanyNumber(req);
   return res.render(Templates.TRADING_STATUS, {
-    backLinkUrl: getConfirmCompanyUrl(companyNumber)
+    backLinkUrl: getConfirmCompanyUrl(companyNumber),
+    templateName: Templates.TRADING_STATUS
   });
 };
 
@@ -31,6 +32,7 @@ export const post = async (req: Request, res: Response) => {
   return res.render(Templates.TRADING_STATUS, {
     tradingStatusErrorMsg: TRADING_STATUS_ERROR,
     backLinkUrl: getConfirmCompanyUrl(companyNumber),
+    templateName: Templates.TRADING_STATUS
   });
 };
 


### PR DESCRIPTION
[BI-9484](https://companieshouse.atlassian.net/jira/software/c/projects/NCS/boards/234?modal=detail&selectedIssue=BI-9484)

Add template name to the render funciton of task list and trading status controllers so that the data events associated with it, is in the correct matomo event category.