### PR TITLE
BI-9701 remove office address from confirm company page

### DIFF
--- a/views/confirm-company.html
+++ b/views/confirm-company.html
@@ -25,15 +25,6 @@
         </p>
         {% endset %}
 
-        {% set registeredAddress %}
-          {{company.registeredOfficeAddress.addressLineOne}}
-          <br/>
-          {{company.registeredOfficeAddress.addressLineTwo}}
-          <br/>
-          {{company.registeredOfficeAddress.postalCode}}
-        {% endset %}
-
-
         {{ govukSummaryList({
           rows: [
             {
@@ -67,14 +58,6 @@
               },
               value: {
                 text: company.type
-              }
-            },
-            {
-              key: {
-                text: "Registered office address"
-              },
-              value: {
-                html: registeredAddress
               }
             },
             {


### PR DESCRIPTION
Removed from cs ui only - remains in the data as it is company profile data that predates the cs development.