### PR TITLE
BI-9954 Change page title of SIC stop page

### DIFF
--- a/src/controllers/tasks/confirm.sic.code.controller.ts
+++ b/src/controllers/tasks/confirm.sic.code.controller.ts
@@ -5,7 +5,7 @@ import { Templates } from "../../types/template.paths";
 import { lookupSicCodeDescription } from "../../utils/api.enumerations";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { getCompanyProfile } from "../../services/company.profile.service";
-import { RADIO_BUTTON_VALUE, SECTIONS, SIC_CODE_ERROR } from "../../utils/constants";
+import { pageTitle, RADIO_BUTTON_VALUE, SECTIONS, SIC_CODE_ERROR } from "../../utils/constants";
 import { SectionStatus, SicCode } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 
@@ -33,6 +33,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     await sendUpdate(req, SECTIONS.SIC, SectionStatus.NOT_CONFIRMED);
     return res.render(Templates.WRONG_SIC, {
       backLinkUrl: urlUtils.getUrlToPath(SIC_PATH, req),
+      pageTitle: pageTitle.STOP_PAGE_SIC,
       templateName: Templates.SIC,
       sickCodeStatus: sicButtonValue
     });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -74,3 +74,7 @@ export enum OFFICER_TYPE {
   NATURAL_DIRECTOR = "naturalDirector",
   CORPORATE_DIRECTORS = "corporateDirector"
 }
+
+export const pageTitle = {
+  STOP_PAGE_SIC: "Incorrect SIC"
+};

--- a/test/controllers/tasks/confirm.sic.code.controller.unit.ts
+++ b/test/controllers/tasks/confirm.sic.code.controller.unit.ts
@@ -14,7 +14,7 @@ import { companyAuthenticationMiddleware } from "../../../src/middleware/company
 import { urlUtils } from "../../../src/utils/url";
 import { getCompanyProfile } from "../../../src/services/company.profile.service";
 import { validCompanyProfile } from "../../mocks/company.profile.mock";
-import { SECTIONS, SIC_CODE_ERROR } from "../../../src/utils/constants";
+import { pageTitle, SECTIONS, SIC_CODE_ERROR } from "../../../src/utils/constants";
 import { sendUpdate } from "../../../src/utils/update.confirmation.statement.submission";
 import { SectionStatus } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 
@@ -65,6 +65,7 @@ describe("Confirm sic code controller tests", () => {
     expect(response.status).toEqual(200);
     expect(response.text).toContain(STOP_PAGE_TEXT);
     expect(response.text).not.toContain(SIC_CODE_DETAILS);
+    expect(response.text).toContain(pageTitle.STOP_PAGE_SIC);
     expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
   });
 

--- a/views/incorrect-information/wrong-sic.html
+++ b/views/incorrect-information/wrong-sic.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-  You cannot use this service - File a confirmation statement
+  {{ pageTitle }}
 {% endblock %}
 {% block backLink %}
   {% include "includes/back-link.html" %}


### PR DESCRIPTION
Updating the page title of the SIC stop page to a title that has been provided by the user tracking team to help them track the users journey (matomo)