### PR TITLE
BI-10080 Removing isPageHeading option from shareholders page radio button element

### DIFF
--- a/views/tasks/shareholders.html
+++ b/views/tasks/shareholders.html
@@ -45,7 +45,6 @@
           fieldset: {
             legend: {
               html: "Are the shareholder details correct?",
-              isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }
           },


### PR DESCRIPTION
This was giving the radio element an h1 tag which was confusing screen readers. 