### PR TITLE
BI-10141 adding explicit padding on summary list values on officers details page

### DIFF
--- a/views/includes/natural-secretaries.html
+++ b/views/includes/natural-secretaries.html
@@ -16,13 +16,13 @@
       <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Appointment date</dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
             <p>{{secretary.dateOfAppointment}}</p>
           </dd>
         </div>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Correspondence address</dt>
-          <dd class="govuk-summary-list__value">
+          <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
           <p>{{secretary.serviceAddress}}</p>
           </dd>
         </div>

--- a/views/tasks/active-officers-details.html
+++ b/views/tasks/active-officers-details.html
@@ -46,43 +46,43 @@
             <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Correspondence address</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>2 Nets Way, Newcastle, NE2 3BB</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Appointed date</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>1 January 2020</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Identification type</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>UK limited company</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Law governed</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>Company Law</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Legal form</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>Limited</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Place registered</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>United Kingdom</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Registration number</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>04512345</p>
                 </dd>
               </div>
@@ -105,43 +105,43 @@
             <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Nationality</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>British</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Country of residence</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>United Kingdom</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Date of birth</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>1 January 1988</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Appointment date</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>20 June 2019</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Occupation</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>Director</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Correspondence address</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>2 Nets Way, Newcastle, NE2 3BB</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Usual residential address</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>2 Nets Way, Newcastle, NE2 3BB</p>
                 </dd>
               </div>
@@ -160,43 +160,43 @@
             <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Nationality</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>British</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Country of residence</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>United Kingdom</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Date of birth</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>16 March 1982</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Appointment date</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>20 June 2019</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Occupation</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>Director</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Correspondence address</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>2 Nets Way, Newcastle, NE2 3BB</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Usual residential address</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>3 Dunk Street, Newcastle, NE2 4TD</p>
                 </dd>
               </div>
@@ -219,43 +219,43 @@
             <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Correspondence address</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>2 Nets Way, Newcastle, NE2 3BB</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Appointed date</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>20 June 2019</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Identification type</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>UK limited company</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Law governed</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>Company Law</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Legal form</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>Limited</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Place registered</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>United Kingdom</p>
                 </dd>
               </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">Registration number</dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__value govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                   <p>0111222</p>
                 </dd>
               </div>


### PR DESCRIPTION
Overriding the standard padding for that value to compress the table rows and match the prototype