### PR TITLE
BI-10139 Move function to get secretaries out of format.ts and into a…

### DIFF
--- a/src/controllers/tasks/active.officers.details.controller.ts
+++ b/src/controllers/tasks/active.officers.details.controller.ts
@@ -7,7 +7,8 @@ import { Templates } from "../../types/template.paths";
 import { Session } from "@companieshouse/node-session-handler";
 import { ActiveOfficerDetails } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { getActiveOfficersDetailsData } from "../../services/active.officers.details.service";
-import { formatSecretaryList } from "../../utils/format";
+import { OFFICER_ROLE } from "../../utils/constants";
+import { formatAddress, formatAddressForDisplay, formatTitleCase } from "../../utils/format";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -15,8 +16,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
     const session: Session = req.session as Session;
     const officers: ActiveOfficerDetails[] = await getActiveOfficersDetailsData(session, transactionId, submissionId);
-    const naturalSecretaryList = formatSecretaryList(officers);
-
+    const naturalSecretaryList = buildSecretaryList(officers);
 
     return res.render(Templates.ACTIVE_OFFICERS_DETAILS, {
       templateName: Templates.ACTIVE_OFFICERS_DETAILS,
@@ -26,4 +26,17 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
   } catch (e) {
     return next(e);
   }
+};
+
+const buildSecretaryList = (officers: ActiveOfficerDetails[]): any[] => {
+  return officers
+    .filter(officer => OFFICER_ROLE.SECRETARY.localeCompare(officer.role, 'en', { sensitivity: 'accent' }) === 0 && !officer.isCorporate)
+    .map(officer => {
+      return {
+        forename: formatTitleCase(officer.foreName1),
+        surname: officer.surname,
+        dateOfAppointment: officer.dateOfAppointment,
+        serviceAddress: formatAddressForDisplay(formatAddress(officer.serviceAddress))
+      };
+    });
 };

--- a/src/controllers/tasks/natural.person.secretaries.controller.ts
+++ b/src/controllers/tasks/natural.person.secretaries.controller.ts
@@ -6,19 +6,18 @@ import { OFFICER_TYPE, RADIO_BUTTON_VALUE, SECRETARY_DETAILS_ERROR, WRONG_DETAIL
 import { Session } from "@companieshouse/node-session-handler";
 import { ActiveOfficerDetails } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { getActiveOfficersDetailsData, getOfficerTypeList } from "../../services/active.officers.details.service";
-import { formatSecretaryList } from "../../utils/format";
 
-export const get = async (req: Request, res: Response, next: NextFunction) => {
+export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
-    const transactionId = urlUtils.getTransactionIdFromRequestParams(req);
-    const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
-    const session: Session = req.session as Session;
-    const officers: ActiveOfficerDetails[] = await getActiveOfficersDetailsData(session, transactionId, submissionId);
-    const secretaryList = formatSecretaryList(officers);
+    // const transactionId = urlUtils.getTransactionIdFromRequestParams(req);
+    // const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
+    // const session: Session = req.session as Session;
+    // const officers: ActiveOfficerDetails[] = await getActiveOfficersDetailsData(session, transactionId, submissionId);
+    // const secretaryList = formatSecretaryList(officers);
     return res.render(Templates.NATURAL_PERSON_SECRETARIES, {
       templateName: Templates.NATURAL_PERSON_SECRETARIES,
       backLinkUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),
-      secretaryList
+      // secretaryList
     });
   } catch (e) {
     return next(e);
@@ -60,12 +59,12 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     // show error message on screen
-    const secretaryList = formatSecretaryList(officers);
+    // const secretaryList = formatSecretaryList(officers);
     return res.render(Templates.NATURAL_PERSON_SECRETARIES, {
       backLinkUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),
       secretaryErrorMsg: SECRETARY_DETAILS_ERROR,
       templateName: Templates.NATURAL_PERSON_SECRETARIES,
-      secretaryList
+      // secretaryList
     });
 
   } catch (e) {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,6 +1,5 @@
 import { RegisteredOfficeAddress } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { ActiveOfficerDetails, Address, PersonOfSignificantControl } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
-import { OFFICER_ROLE } from "./constants";
 
 export const formatTitleCase = (str: string|undefined): string =>  {
   if (!str) {
@@ -93,23 +92,4 @@ export const formatPSCForDisplay = (psc: PersonOfSignificantControl): PersonOfSi
   clonedPsc.legalForm = formatTitleCase(psc.legalForm);
 
   return clonedPsc;
-};
-
-export const formatSecretaryList = (officers: ActiveOfficerDetails[]): any[] => {
-  const secretaryList = new Array(0);
-  for (const officer of officers) {
-    if (OFFICER_ROLE.SECRETARY.localeCompare(officer.role, 'en', { sensitivity: 'accent' }) === 0 && !officer.isCorporate ) {
-      const serviceAddress = formatAddressForDisplay(formatAddress(officer.serviceAddress));
-      const surname = officer.surname;
-      const forename = formatTitleCase(officer.foreName1);
-      const secretaryObj = {
-        forename,
-        surname,
-        dateOfAppointment: officer.dateOfAppointment,
-        serviceAddress,
-      };
-      secretaryList.push(secretaryObj);
-    }
-  }
-  return secretaryList;
 };

--- a/test/controllers/tasks/active.officers.details.controller.unit.ts
+++ b/test/controllers/tasks/active.officers.details.controller.unit.ts
@@ -1,8 +1,8 @@
 jest.mock("../../../src/middleware/company.authentication.middleware");
 jest.mock("../../../src/services/active.officers.details.service");
 jest.mock("../../../src/services/confirmation.statement.service");
-jest.mock("../../../src/utils/format");
 jest.mock("../../../src/utils/update.confirmation.statement.submission");
+jest.mock("../../../src/middleware/company.authentication.middleware");
 
 import mocks from "../../mocks/all.middleware.mock";
 import request from "supertest";
@@ -10,26 +10,18 @@ import app from "../../../src/app";
 import { ACTIVE_OFFICERS_DETAILS_PATH, urlParams } from "../../../src/types/page.urls";
 import { companyAuthenticationMiddleware } from "../../../src/middleware/company.authentication.middleware";
 import { getActiveOfficersDetailsData } from "../../../src/services/active.officers.details.service";
-import { formatSecretaryList } from "../../../src/utils/format";
-
-jest.mock("../../../src/middleware/company.authentication.middleware");
+import { mockActiveOfficersDetails } from "../../mocks/active.officers.details.mock";
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
 const mockGetActiveOfficerDetails = getActiveOfficersDetailsData as jest.Mock;
-const mockFormatSecretaryList = formatSecretaryList as jest.Mock;
+mockGetActiveOfficerDetails.mockResolvedValue(mockActiveOfficersDetails);
 
 const COMPANY_NUMBER = "12345678";
 const ACTIVE_OFFICER_DETAILS_URL = ACTIVE_OFFICERS_DETAILS_PATH.replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER);
 const EXPECTED_ERROR_TEXT = "Sorry, the service is unavailable";
 const PAGE_HEADING = "Check the officers' details";
-const dummyNaturalSecretary = {
-  forename: "Joe",
-  surname: "Bloggs",
-  dateOfAppointment: "01/01/2022",
-  serviceAddress: "1 No Street, Nowhere"
-};
-const officers: any[] = [dummyNaturalSecretary];
+
 
 describe("Active directors controller tests", () => {
 
@@ -48,16 +40,14 @@ describe("Active directors controller tests", () => {
       expect(response.text).toContain(PAGE_HEADING);
     });
 
-    it("Should display natural secretary details", async () => {
-      mockFormatSecretaryList.mockReturnValueOnce(officers);
-
+    it("Should display non corporate secretary details", async () => {
       const response = await request(app).get(ACTIVE_OFFICER_DETAILS_URL);
 
       expect(mockGetActiveOfficerDetails).toHaveBeenCalled();
-      expect(response.text).toContain(dummyNaturalSecretary.forename);
-      expect(response.text).toContain(dummyNaturalSecretary.surname);
-      expect(response.text).toContain(dummyNaturalSecretary.dateOfAppointment);
-      expect(response.text).toContain(dummyNaturalSecretary.serviceAddress);
+      expect(response.text).toContain("West");
+      expect(response.text).toContain("HAM");
+      expect(response.text).toContain("1 January 2009");
+      expect(response.text).toContain("Diddly Squat Farm Shop, Chadlington, Thisshire, England, OX7 3PE");
     });
 
     it("Should navigate to an error page if the called service throws an error", async () => {

--- a/test/controllers/tasks/natural.person.secretaries.controller.unit.ts
+++ b/test/controllers/tasks/natural.person.secretaries.controller.unit.ts
@@ -9,24 +9,17 @@ import { companyAuthenticationMiddleware } from "../../../src/middleware/company
 import { CORPORATE_DIRECTORS_PATH, CORPORATE_SECRETARIES_PATH, NATURAL_PERSON_DIRECTORS_PATH, NATURAL_PERSON_SECRETARIES_PATH, urlParams } from "../../../src/types/page.urls";
 import { urlUtils } from "../../../src/utils/url";
 import { SECRETARY_DETAILS_ERROR, WRONG_DETAILS_UPDATE_SECRETARY } from "../../../src/utils/constants";
-import { formatSecretaryList } from "../../../src/utils/format";
 import { getActiveOfficersDetailsData, getOfficerTypeList } from "../../../src/services/active.officers.details.service";
 import { mockActiveOfficersDetails } from "../../mocks/active.officers.details.mock";
 
-const FORMATTED_SERVICE_ADDRESS = "Formatted Service Address";
-const FORENAME = "DUMMYFORENAME";
-const SURNAME = "DUMMYSURNAME";
-const DATE_OF_APPOINTMENT = "03 August 2003";
+// const FORMATTED_SERVICE_ADDRESS = "Formatted Service Address";
+// const FORENAME = "DUMMYFORENAME";
+// const SURNAME = "DUMMYSURNAME";
+// const DATE_OF_APPOINTMENT = "03 August 2003";
 
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
 mockCompanyAuthenticationMiddleware.mockImplementation((req, res, next) => next());
-const mockformatSecretaryList = formatSecretaryList as jest.Mock;
-mockformatSecretaryList.mockReturnValue([{
-  forename: FORENAME,
-  surname: SURNAME,
-  dateOfAppointment: DATE_OF_APPOINTMENT,
-  serviceAddress: FORMATTED_SERVICE_ADDRESS
-}]);
+
 const mockGetActiveOfficerDetails = getActiveOfficersDetailsData as jest.Mock;
 mockGetActiveOfficerDetails.mockResolvedValue(mockActiveOfficersDetails);
 const mockGetOfficerTypeList = getOfficerTypeList as jest.Mock;

--- a/test/utils/format.unit.ts
+++ b/test/utils/format.unit.ts
@@ -1,6 +1,5 @@
-import { formatAddressForDisplay, formatSecretaryList, formatTitleCase } from "../../src/utils/format";
+import { formatAddressForDisplay, formatTitleCase } from "../../src/utils/format";
 import { Address } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
-import { mockActiveOfficersDetails } from "../mocks/active.officers.details.mock";
 
 
 describe("formatTitleCase tests", () => {
@@ -27,18 +26,3 @@ describe("formatAddressForDisplay tests", () => {
     expect(formattedAddress).toBe("10 my street, South Glamorgan, UK, CF1 1AA");
   });
 });
-
-describe("formatSecretaryList tests", () => {
-  it("should return formated secretary list", () => {
-    const formattedOfficer = formatSecretaryList(mockActiveOfficersDetails);
-    const expectedOfficer = {
-      forename: "West",
-      surname: "HAM",
-      dateOfAppointment: "1 January 2009",
-      serviceAddress: "Diddly Squat Farm Shop, Chadlington, Thisshire, England, OX7 3PE"
-    };
-
-    expect(formattedOfficer[0]).toEqual(expectedOfficer);
-  });
-});
-


### PR DESCRIPTION
…ctive.officers.details.controller and updated tests

Refactored the formatSecretaryList function in format and moved it to active.details.controller.
Had to comment out some old references to it in the natural.person.secretaries files but these are unused files and are to be removed.