### PR TITLE
BI-9960 Fix to only add officer row if list is present and not empty

### DIFF
--- a/views/tasks/active-officers-details.html
+++ b/views/tasks/active-officers-details.html
@@ -100,13 +100,15 @@
         {% endset %}
 
       {% set officerRows = [] %}
-      {% if naturalSecretaryList %}
+      {% if naturalSecretaryList|length %}
         {% set officerRows = (officerRows.push([{html: naturalSecretaryHTML}]), officerRows) %}
       {% endif %}
-      {% if corporateSecretaryList %}
+      {% if corporateSecretaryList|length %}
         {% set officerRows = (officerRows.push([{html: corporateSecretaryHTML}]), officerRows) %}
       {% endif %}
-      {% set officerRows = (officerRows.push([{html: directorHTML}]), officerRows) %}
+      {% if naturalDirectorList|length %}
+        {% set officerRows = (officerRows.push([{html: directorHTML}]), officerRows) %}
+      {% endif %}
       {% set officerRows = (officerRows.push([{html: corpDirectorsHTML}]), officerRows) %}
 
         {{ govukTable({


### PR DESCRIPTION
Empty rows were still being shown (with separator line) if the list was empty. 
Added a length check which also works if no list is passed to template
Added the missing list check to the (natural) directors row

https://stackoverflow.com/questions/37905073/check-if-an-object-is-empty-in-nunjucks