### PR TITLE
BI-10196 Changing officer details header stylings to match prototype …

### DIFF
--- a/views/includes/corporate-directors.html
+++ b/views/includes/corporate-directors.html
@@ -1,7 +1,7 @@
 {% if corporateDirectorList.length > 1 %}
-  <h2 class="govuk-heading-m">{{ corporateDirectorList.length }} corporate directors</h2>
+  <h2 class="govuk-heading-">{{ corporateDirectorList.length }} corporate directors</h2>
 {% elseif corporateDirectorList.length === 1 %}
-  <h2 class="govuk-heading-m">1 corporate director</h2>
+  <h2 class="govuk-heading-">1 corporate director</h2>
 {% endif %}
 
 {% for officer in corporateDirectorList %}

--- a/views/includes/corporate-secretaries.html
+++ b/views/includes/corporate-secretaries.html
@@ -1,7 +1,7 @@
 {% if corporateSecretaryList.length > 1 %}
-  <h2 class="govuk-heading-m">{{ corporateSecretaryList.length }} corporate secretaries</h2>
+  <h2 class="govuk-heading-">{{ corporateSecretaryList.length }} corporate secretaries</h2>
 {% elseif corporateSecretaryList.length === 1 %}
-  <h2 class="govuk-heading-m">1 corporate secretary</h2>
+  <h2 class="govuk-heading-">1 corporate secretary</h2>
 {% endif %}
 
 {% for officer in corporateSecretaryList %}

--- a/views/includes/natural-directors.html
+++ b/views/includes/natural-directors.html
@@ -1,7 +1,7 @@
 {% if naturalDirectorList.length > 1 %}
-  <h2 class="govuk-heading-m">{{ naturalDirectorList.length }} directors</h2>
+  <h2 class="govuk-heading-">{{ naturalDirectorList.length }} directors</h2>
 {% elseif naturalDirectorList.length === 1 %}
-  <h2 class="govuk-heading-m">1 director</h2>
+  <h2 class="govuk-heading-">1 director</h2>
 {% endif %}
 {% for director in naturalDirectorList %}
   <div class="govuk-summary-card govuk-!-margin-bottom-4">

--- a/views/includes/natural-secretaries.html
+++ b/views/includes/natural-secretaries.html
@@ -1,7 +1,7 @@
 {% if naturalSecretaryList.length > 1 %}
-  <h2 class="govuk-heading-m">{{ naturalSecretaryList.length }} secretaries</h2>
+  <h2 class="govuk-heading-">{{ naturalSecretaryList.length }} secretaries</h2>
 {% elseif naturalSecretaryList.length === 1 %}
-  <h2 class="govuk-heading-m">1 secretary</h2>
+  <h2 class="govuk-heading-">1 secretary</h2>
 {% endif %}
 {% for secretary in naturalSecretaryList %}
   <div class="govuk-summary-card govuk-!-margin-bottom-4">


### PR DESCRIPTION
…to fix table spacing

Changing the class govuk-heading-m back to govuk-heading- to fix table spacing on active officers details screen.
The govuk-heading- class has different margins to govuk-heading-m