### PR TITLE
BI-10288 Extract individual pscs and display

### DIFF
--- a/src/controllers/tasks/active.officers.details.controller.ts
+++ b/src/controllers/tasks/active.officers.details.controller.ts
@@ -6,7 +6,6 @@ import { Session } from "@companieshouse/node-session-handler";
 import { ActiveOfficerDetails, SectionStatus } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { getActiveOfficersDetailsData } from "../../services/active.officers.details.service";
 import {
-  LOCALE_EN,
   OFFICER_DETAILS_ERROR,
   OFFICER_ROLE,
   RADIO_BUTTON_VALUE,
@@ -14,7 +13,13 @@ import {
   WRONG_DETAILS_UPDATE_OFFICER,
   WRONG_DETAILS_UPDATE_OFFICERS
 } from "../../utils/constants";
-import { formatAddress, formatAddressForDisplay, formatTitleCase, toUpperCase } from "../../utils/format";
+import {
+  equalsIgnoreCase,
+  formatAddress,
+  formatAddressForDisplay,
+  formatTitleCase,
+  toUpperCase
+} from "../../utils/format";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 import { lookupIdentificationType } from "../../utils/api.enumerations";
 
@@ -131,8 +136,4 @@ const buildOfficerLists = (officers: ActiveOfficerDetails[]): any => {
     naturalDirectorList: buildDirectorList(officers),
     corporateDirectorList: buildCorporateOfficerList(officers, OFFICER_ROLE.DIRECTOR),
   };
-};
-
-const equalsIgnoreCase = (officerRole: string, wantedOfficerRole: OFFICER_ROLE): boolean => {
-  return wantedOfficerRole.localeCompare(officerRole, LOCALE_EN, { sensitivity: 'accent' }) === 0;
 };

--- a/src/controllers/tasks/active.psc.details.controller.ts
+++ b/src/controllers/tasks/active.psc.details.controller.ts
@@ -5,11 +5,9 @@ import { urlUtils } from "../../utils/url";
 import { PersonOfSignificantControl } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { getPscs } from "../../services/psc.service";
 import { Session } from "@companieshouse/node-session-handler";
-import { appointmentTypes, LOCALE_EN } from "../../utils/constants";
-import { formatAddressForDisplay, formatPSCForDisplay } from "../../utils/format";
+import { appointmentTypes } from "../../utils/constants";
+import { equalsIgnoreCase, formatAddressForDisplay, formatPSCForDisplay } from "../../utils/format";
 import { toReadableFormat } from "../../utils/date";
-
-
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -51,8 +49,4 @@ const buildIndividualPscList = (pscs: PersonOfSignificantControl[]): any[] => {
         dateOfAppointment: dateOfAppointment
       };
     });
-};
-
-const equalsIgnoreCase = (pscType: string, wantedPscType: string): boolean => {
-  return wantedPscType.localeCompare(pscType, LOCALE_EN, { sensitivity: 'accent' }) === 0;
 };

--- a/src/controllers/tasks/active.psc.details.controller.ts
+++ b/src/controllers/tasks/active.psc.details.controller.ts
@@ -2,14 +2,57 @@ import { NextFunction, Request, Response } from "express";
 import { TASK_LIST_PATH } from "../../types/page.urls";
 import { Templates } from "../../types/template.paths";
 import { urlUtils } from "../../utils/url";
+import { PersonOfSignificantControl } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
+import { getPscs } from "../../services/psc.service";
+import { Session } from "@companieshouse/node-session-handler";
+import { appointmentTypes, LOCALE_EN } from "../../utils/constants";
+import { formatAddressForDisplay, formatPSCForDisplay } from "../../utils/format";
+import { toReadableFormat } from "../../utils/date";
 
-export const get = (req: Request, res: Response, next: NextFunction) => {
+
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const transactionId = urlUtils.getTransactionIdFromRequestParams(req);
+    const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
+    const pscs: PersonOfSignificantControl[] = await getPscs(req.session as Session, transactionId, submissionId);
+
+    const pscLists = buildPscLists(pscs);
     return res.render(Templates.ACTIVE_PSC_DETAILS, {
       templateName: Templates.ACTIVE_PSC_DETAILS,
       backLinkUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),
+      pscList: pscLists.individualPscList
     });
   } catch (e) {
     return next(e);
   }
+};
+
+const buildPscLists = (pscs: PersonOfSignificantControl[]): any => {
+  return {
+    individualPscList: buildIndividualPscList(pscs)
+  };
+};
+
+const buildIndividualPscList = (pscs: PersonOfSignificantControl[]): any[] => {
+  return pscs
+    .filter(psc => equalsIgnoreCase(psc.appointmentType, appointmentTypes.INDIVIDUAL_PSC))
+    .map(psc  => {
+      const formattedPsc: PersonOfSignificantControl = formatPSCForDisplay(psc);
+      const ura = formattedPsc.address ? formatAddressForDisplay(formattedPsc.address) : "";
+      const serviceAddress = formattedPsc.serviceAddress ? formatAddressForDisplay(formattedPsc.serviceAddress) : "";
+      const dob = psc.dateOfBirthIso ? toReadableFormat(psc.dateOfBirthIso) : "";
+      const dateOfAppointment = toReadableFormat(psc.appointmentDate);
+      return {
+        formattedPsc: formattedPsc,
+        ura: ura,
+        serviceAddress: serviceAddress,
+        dob: dob,
+        dateOfAppointment: dateOfAppointment
+      };
+    });
+};
+
+const equalsIgnoreCase = (pscType: string, wantedPscType: string): boolean => {
+  return wantedPscType.localeCompare(pscType, LOCALE_EN, { sensitivity: 'accent' }) === 0;
 };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,6 @@
 import { RegisteredOfficeAddress } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { ActiveOfficerDetails, Address, PersonOfSignificantControl } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
+import { LOCALE_EN } from "./constants";
 
 export const formatTitleCase = (str: string|undefined): string =>  {
   if (!str) {
@@ -99,4 +100,8 @@ export const toUpperCase = (str: string | undefined): string => {
     return "";
   }
   return str.toUpperCase();
+};
+
+export const equalsIgnoreCase = (compareTo: string, compare: string): boolean => {
+  return compare.localeCompare(compareTo, LOCALE_EN, { sensitivity: 'accent' }) === 0;
 };

--- a/test/controllers/tasks/active.psc.details.controller.unit.ts
+++ b/test/controllers/tasks/active.psc.details.controller.unit.ts
@@ -1,11 +1,18 @@
+import {mockPscList} from "../../mocks/active.psc.details.controller.mock";
+
+jest.mock("../../../src/services/psc.service");
+
 import mocks from "../../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../../src/app";
 import { ACTIVE_PSC_DETAILS_PATH, urlParams } from "../../../src/types/page.urls";
+import { getPscs } from "../../../src/services/psc.service";
 
 const COMPANY_NUMBER = "12345678";
 const ACTIVE_PSC_DETAILS_URL = ACTIVE_PSC_DETAILS_PATH.replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER);
 const PAGE_HEADING = "Review the people with significant control";
+
+const mockGetPscs = getPscs as jest.Mock;
 
 describe("Active psc details controller tests", () => {
 
@@ -13,14 +20,25 @@ describe("Active psc details controller tests", () => {
     mocks.mockAuthenticationMiddleware.mockClear();
     mocks.mockServiceAvailabilityMiddleware.mockClear();
     mocks.mockSessionMiddleware.mockClear();
+    mockGetPscs.mockClear();
   });
 
   describe("get tests", () => {
 
-    it("Should navigate to active psc details page", async () => {
+    it("Should navigate to psc page and display individual psc details", async () => {
+      mockGetPscs.mockResolvedValueOnce(mockPscList);
       const response = await request(app).get(ACTIVE_PSC_DETAILS_URL);
-
       expect(response.text).toContain(PAGE_HEADING);
+      expect(response.text).toContain("Joe");
+      expect(response.text).toContain("Bloggs");
+      expect(response.text).toContain("British");
+      expect(response.text).toContain("21 March 1965");
+      expect(response.text).toContain("1 January 2012");
+      expect(response.text).toContain("10 This Road, This Town, Thisshire, Thisland, TH1 1AB");
+      expect(response.text).toContain("Diddly Squat Farm Shop, Chadlington, Thisshire, England, OX7 3PE");
+      expect(response.text).toContain("United Kingdom");
+      expect(response.text).toContain("75% or more of shares held as a person");
+      expect(response.text).toContain("Ownership of voting rights - more than 75%");
     });
   });
 });

--- a/test/controllers/tasks/active.psc.details.controller.unit.ts
+++ b/test/controllers/tasks/active.psc.details.controller.unit.ts
@@ -1,5 +1,3 @@
-import {mockPscList} from "../../mocks/active.psc.details.controller.mock";
-
 jest.mock("../../../src/services/psc.service");
 
 import mocks from "../../mocks/all.middleware.mock";
@@ -7,6 +5,7 @@ import request from "supertest";
 import app from "../../../src/app";
 import { ACTIVE_PSC_DETAILS_PATH, urlParams } from "../../../src/types/page.urls";
 import { getPscs } from "../../../src/services/psc.service";
+import { mockPscList } from "../../mocks/active.psc.details.controller.mock";
 
 const COMPANY_NUMBER = "12345678";
 const ACTIVE_PSC_DETAILS_URL = ACTIVE_PSC_DETAILS_PATH.replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER);

--- a/test/mocks/active.psc.details.controller.mock.ts
+++ b/test/mocks/active.psc.details.controller.mock.ts
@@ -1,0 +1,49 @@
+import { Address } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
+import { appointmentTypes } from "../../src/utils/constants";
+
+const mockNameElements = {
+  forename: "Joe",
+  surname: "Bloggs",
+  title: "Mr"
+};
+
+const mockPscUra: Address = {
+  addressLine1: "10 this road",
+  addressLine2: undefined,
+  careOf: undefined,
+  country: "Thisland",
+  locality: "This town",
+  poBox: undefined,
+  postalCode: "TH1 1AB",
+  premises: undefined,
+  region: "Thisshire"
+};
+
+const mockPscServiceAddress: Address = {
+  addressLine1: "Diddly squat farm shop",
+  addressLine2: undefined,
+  careOf: undefined,
+  country: "England",
+  locality: "Chadlington",
+  poBox: undefined,
+  postalCode: "OX7 3PE",
+  premises: undefined,
+  region: "Thisshire"
+};
+
+export const mockPscList: any[] = [
+  {
+    appointmentType: appointmentTypes.INDIVIDUAL_PSC,
+    nameElements: mockNameElements,
+    nationality: "British",
+    countryOfResidence: "United Kingdom",
+    address: mockPscUra,
+    serviceAddress: mockPscServiceAddress,
+    dateOfBirthIso: "1965-03-21",
+    appointmentDate: "1 January 2012",
+    naturesOfControl: [
+      "75% or more of shares held as a person",
+      "Ownership of voting rights - more than 75%"
+    ]
+  }
+];

--- a/views/tasks/active-psc-details.html
+++ b/views/tasks/active-psc-details.html
@@ -41,77 +41,18 @@
             html: pscDetails
           }) }}
 
-          {% set pscHTML %}
-            <h2 class="govuk-heading-m">1 individual person</h2>
-            <div class="govuk-summary-card govuk-!-margin-bottom-4">
-              <div class="govuk-summary-card_heading govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-right-3 govuk-!-padding-left-3" style="display: flex; justify-content: space-between; align-items: center">
-                <p class="govuk-!-font-weight-bold govuk-!-margin-0">IRVING, Kyrie</p>
-                  {{govukTag({
-                    text: "Active",
-                    classes: "govuk-tag--green"
-                  })}}
-              </div>
-              <div style="display: flex" class="govuk-!-padding-1" style="border-bottom: 0px">
-                <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Nationality</dt>
-                      <dd class="govuk-summary-list__value">
-                        <p>British</p>
-                      </dd>
-                  </div>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Country of residence</dt>
-                      <dd class="govuk-summary-list__value">
-                        <p>England</p>
-                      </dd>
-                  </div>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Date of birth</dt>
-                      <dd class="govuk-summary-list__value">
-                        <p>1 January 1988</p>
-                      </dd>
-                  </div>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Notification date</dt>
-                      <dd class="govuk-summary-list__value">
-                        <p>1 January 2019</p>
-                      </dd>
-                  </div>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Correspondence address</dt>
-                      <dd class="govuk-summary-list__value">
-                        <p>2 Nets Way, Newcastle, NE2 3BB</p>
-                      </dd>
-                  </div>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Usual residential address</dt>
-                      <dd class="govuk-summary-list__value">
-                        <p>1 Bucks Street, Birmingham, BD6 6JD</p>
-                      </dd>
-                  </div>
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">Nature of control</dt>
-                    <dd class="govuk-summary-list__value">
-                      <ul class="govuk-bullet__list">
-                        <li>
-                          <p>Ownership of voting rights - more than 50%</p>
-                        </li>
-                        <li>
-                          <p>Ownership of shares - more than 50%</p>
-                        </li>
-                      </ul>
-                    </dd>
-                  </div>
-                </dl>
-              </div>
-            </div>
+          {% set individualPscHtml %}
+            {% include "tasks/includes/normal-psc.html" %}
+          {% endset %}
+
+          {% set todoHtml %}
             <h2 class="govuk-heading-m">1 relevant legal entity</h2>
             <div class="govuk-summary-card govuk-!-margin-bottom-4">
               <div class="govuk-summary-card_heading govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-right-3 govuk-!-padding-left-3" style="display: flex; justify-content: space-between; align-items: center">
                 <p class="govuk-!-font-weight-bold govuk-!-margin-0">BROOKLYN NETS LIMITED</p>
                 {{govukTag({
-                  text: "Active",
-                  classes: "govuk-tag--green"
+                text: "Active",
+                classes: "govuk-tag--green"
                 })}}
               </div>
               <div style="display: flex" class="govuk-!-padding-1" style="border-bottom: 0px">
@@ -177,10 +118,10 @@
             <div class="govuk-summary-card govuk-!-margin-bottom-4">
               <div class="govuk-summary-card_heading govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-right-3 govuk-!-padding-left-3" style="display: flex; justify-content: space-between; align-items: center">
                 <p class="govuk-!-font-weight-bold govuk-!-margin-0">AYR BAPTIST CHURCH</p>
-                 {{govukTag({
-                  text: "Active",
-                  classes: "govuk-tag--green"
-                 })}}
+                {{govukTag({
+                text: "Active",
+                classes: "govuk-tag--green"
+                })}}
               </div>
               <div style="display: flex" class="govuk-!-padding-1" style="border-bottom: 0px">
                 <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
@@ -223,15 +164,14 @@
             </div>
           {% endset %}
 
+          {% set pscHTML = [] %}
+          {% if pscList|length %}
+            {% set pscHTML = (pscHTML.push([{html: individualPscHtml}]), pscHTML) %}
+          {% endif %}
+          {% set pscHTML = (pscHTML.push([{html: todoHtml}]), pscHTML) %}
+
           {{ govukTable({
-            rows:
-            [
-              [
-                {
-                  html: pscHTML
-                }
-              ]
-            ]
+            rows: pscHTML
           }) }}
           {% if scenario.company.recentFiling === 'yes' %}
             {% if psc === 'yes' %}

--- a/views/tasks/active-psc-details.html
+++ b/views/tasks/active-psc-details.html
@@ -51,8 +51,8 @@
               <div class="govuk-summary-card_heading govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-right-3 govuk-!-padding-left-3" style="display: flex; justify-content: space-between; align-items: center">
                 <p class="govuk-!-font-weight-bold govuk-!-margin-0">BROOKLYN NETS LIMITED</p>
                 {{govukTag({
-                text: "Active",
-                classes: "govuk-tag--green"
+                  text: "Active",
+                  classes: "govuk-tag--green"
                 })}}
               </div>
               <div style="display: flex" class="govuk-!-padding-1" style="border-bottom: 0px">
@@ -119,8 +119,8 @@
               <div class="govuk-summary-card_heading govuk-!-padding-top-4 govuk-!-padding-bottom-4 govuk-!-padding-right-3 govuk-!-padding-left-3" style="display: flex; justify-content: space-between; align-items: center">
                 <p class="govuk-!-font-weight-bold govuk-!-margin-0">AYR BAPTIST CHURCH</p>
                 {{govukTag({
-                text: "Active",
-                classes: "govuk-tag--green"
+                  text: "Active",
+                  classes: "govuk-tag--green"
                 })}}
               </div>
               <div style="display: flex" class="govuk-!-padding-1" style="border-bottom: 0px">

--- a/views/tasks/includes/normal-psc.html
+++ b/views/tasks/includes/normal-psc.html
@@ -15,12 +15,6 @@
     <div style="display: flex; border-bottom: 0" class="govuk-!-padding-1">
       <dl style="display: block" class="govuk-summary-list govuk-!-margin-3">
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Notification date</dt>
-          <dd class="govuk-summary-list__value">
-            <p>{{ psc.dateOfAppointment }}</p>
-          </dd>
-        </div>
-        <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">Nationality</dt>
           <dd class="govuk-summary-list__value">
             <p>{{ psc.formattedPsc.nationality }}</p>
@@ -36,6 +30,12 @@
           <dt class="govuk-summary-list__key">Date of birth</dt>
           <dd class="govuk-summary-list__value">
             <p>{{ psc.dob }}</p>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Notification date</dt>
+          <dd class="govuk-summary-list__value">
+            <p>{{ psc.dateOfAppointment }}</p>
           </dd>
         </div>
         <div class="govuk-summary-list__row">


### PR DESCRIPTION
Updated template to use existing includes for individual psc and to add the other types.
Updated controller and based on the work completed for the active officer controller, reusing the existing formatting.