### PR TITLE
BI-10369 Fix mock data structure for mockPersonsOfSignificantControl

### DIFF
--- a/test/mocks/person.of.significant.control.mock.ts
+++ b/test/mocks/person.of.significant.control.mock.ts
@@ -15,6 +15,7 @@ export const mockPersonsOfSignificantControl: PersonOfSignificantControl[] = [
       region: "region"
     },
     appointmentType: "5007",
+    appointmentDate: "1999-11-23",
     companyName: "comp name",
     countryOfResidence: "UK",
     dateOfBirth: {
@@ -33,9 +34,11 @@ export const mockPersonsOfSignificantControl: PersonOfSignificantControl[] = [
     nationality: "nationality",
     naturesOfControl: [ "noc1", "noc2" ],
     registrationNumber: "reg no",
-    serviceAddressLine1: "serv line 1",
-    serviceAddressPostCode: "serv post code",
-    serviceAddressPostTown: "serv town"
+    serviceAddress: {
+      addressLine1: "serv line 1",
+      locality: "serv post code",
+      postalCode: "serv town",
+    }
   }
 ];
 

--- a/test/mocks/person.of.significant.control.mock.ts
+++ b/test/mocks/person.of.significant.control.mock.ts
@@ -36,8 +36,8 @@ export const mockPersonsOfSignificantControl: PersonOfSignificantControl[] = [
     registrationNumber: "reg no",
     serviceAddress: {
       addressLine1: "serv line 1",
-      locality: "serv post code",
-      postalCode: "serv town",
+      locality: "serv town",
+      postalCode: "serv post code",
     }
   }
 ];


### PR DESCRIPTION
The mocked data didn't match the structure defined in PersonOfSignificantControl and was throwing a warning in test and wen you viewed the file in your IDE