### PR TITLE
Bi 10494 new controller invalid company status

### DIFF
--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -10,7 +10,7 @@ import { checkEligibility } from "../services/eligibility.service";
 import {
   EligibilityStatusCode, NextMadeUpToDate
 } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
-import { CREATE_TRANSACTION_PATH } from "../types/page.urls";
+import { CREATE_TRANSACTION_PATH, INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM } from "../types/page.urls";
 import { urlUtils } from "../utils/url";
 import { toReadableFormat } from "../utils/date";
 
@@ -65,6 +65,11 @@ const isCompanyValidForService = (eligibilityStatusCode: EligibilityStatusCode):
   eligibilityStatusCode === EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE;
 
 const displayEligibilityStopPage = (res: Response, eligibilityStatusCode: EligibilityStatusCode, company: CompanyProfile) => {
+  const stopPagePath: string = stopPagesPathMap[eligibilityStatusCode];
+  if (stopPagePath) {
+    return res.redirect(urlUtils.setQueryParam(stopPagePath, URL_QUERY_PARAM.COMPANY_NUMBER, company.companyNumber));
+  }
+
   const stopPage: string = stopPages[eligibilityStatusCode];
   if (!stopPage) {
     throw new Error(`Unknown eligibilityStatusCode ${eligibilityStatusCode}`);
@@ -79,8 +84,11 @@ const createNewConfirmationStatement = async (session: Session) => {
   }
 };
 
+const stopPagesPathMap = {
+  [EligibilityStatusCode.INVALID_COMPANY_STATUS]: INVALID_COMPANY_STATUS_PATH
+};
+
 const stopPages = {
-  [EligibilityStatusCode.INVALID_COMPANY_STATUS]: Templates.INVALID_COMPANY_STATUS,
   [EligibilityStatusCode.INVALID_COMPANY_TRADED_STATUS_USE_WEBFILING]: Templates.USE_WEBFILING,
   [EligibilityStatusCode.INVALID_COMPANY_TYPE_USE_WEB_FILING]: Templates.USE_WEBFILING,
   [EligibilityStatusCode.INVALID_COMPANY_APPOINTMENTS_INVALID_NUMBER_OF_OFFICERS]: Templates.USE_WEBFILING,

--- a/src/controllers/confirm.company.controller.ts
+++ b/src/controllers/confirm.company.controller.ts
@@ -67,6 +67,7 @@ const isCompanyValidForService = (eligibilityStatusCode: EligibilityStatusCode):
 const displayEligibilityStopPage = (res: Response, eligibilityStatusCode: EligibilityStatusCode, company: CompanyProfile) => {
   const stopPagePath: string = stopPagesPathMap[eligibilityStatusCode];
   if (stopPagePath) {
+    // setQueryParam should 'inject' the param if it is present. Not all paths will need a param so should be unaffected by the setQueryParam
     return res.redirect(urlUtils.setQueryParam(stopPagePath, URL_QUERY_PARAM.COMPANY_NUMBER, company.companyNumber));
   }
 

--- a/src/controllers/invalid.company.status.controller.ts
+++ b/src/controllers/invalid.company.status.controller.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from "express";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { getCompanyProfile } from "../services/company.profile.service";
+import { Templates } from "../types/template.paths";
+import { URL_QUERY_PARAM } from "../types/page.urls";
+
+export const get = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const companyNumber = req.query[URL_QUERY_PARAM.COMPANY_NUMBER];
+    const company: CompanyProfile = await getCompanyProfile(companyNumber as string);
+    return res.render(Templates.INVALID_COMPANY_STATUS, {
+      company,
+      templateName: Templates.INVALID_COMPANY_STATUS
+    });
+  } catch (e) {
+    return next(e);
+  }
+};

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -18,6 +18,7 @@ import * as registeredLocationsRoute from "../controllers/tasks/register.locatio
 import * as reviewRoute from "../controllers/review.controller";
 import * as confirmationRoute from "../controllers/confirmation.controller";
 import * as paymentCallbackRoute from "../controllers/payment.callback.controller";
+import * as invalidCompanyStatusRoute from "../controllers/invalid.company.status.controller";
 import * as urls from "../types/page.urls";
 import { Templates } from "../types/template.paths";
 
@@ -86,3 +87,5 @@ router.post(urls.REVIEW, reviewRoute.post);
 router.get(urls.CONFIRMATION, confirmationRoute.get);
 
 router.get(urls.PAYMENT_CALLBACK, paymentCallbackRoute.get);
+
+router.get(urls.INVALID_COMPANY_STATUS, invalidCompanyStatusRoute.get);

--- a/src/types/page.urls.ts
+++ b/src/types/page.urls.ts
@@ -7,6 +7,7 @@ export enum urlParams {
 }
 
 export enum URL_QUERY_PARAM {
+  COMPANY_NUMBER = "companyNumber",
   IS_PSC = "isPsc"
 }
 
@@ -16,6 +17,9 @@ export const COMPANY_AUTH_PROTECTED_BASE = `/company/:${urlParams.PARAM_COMPANY_
 export const ACTIVE_SUBMISSION_BASE = COMPANY_AUTH_PROTECTED_BASE +
   `transaction/:${urlParams.PARAM_TRANSACTION_ID}/submission/:${urlParams.PARAM_SUBMISSION_ID}/`;
 
+
+// Use _PATH consts for redirects
+// Use const without _PATH to match the url in the routes.ts
 export const ACCESSIBILITY_STATEMENT = SEPARATOR + Templates.ACCESSIBILITY_STATEMENT;
 export const CONFIRM_COMPANY = SEPARATOR + Templates.CONFIRM_COMPANY;
 export const CONFIRMATION_STATEMENT = "/confirmation-statement";
@@ -55,3 +59,5 @@ export const CONFIRMATION = ACTIVE_SUBMISSION_BASE + "confirmation";
 export const CONFIRMATION_PATH = CONFIRMATION_STATEMENT + CONFIRMATION;
 export const PAYMENT_CALLBACK = ACTIVE_SUBMISSION_BASE + "payment-callback";
 export const PAYMENT_CALLBACK_PATH = CONFIRMATION_STATEMENT + PAYMENT_CALLBACK;
+export const INVALID_COMPANY_STATUS = "/invalid-company-status";
+export const INVALID_COMPANY_STATUS_PATH = CONFIRMATION_STATEMENT + INVALID_COMPANY_STATUS + `?${URL_QUERY_PARAM.COMPANY_NUMBER}={${URL_QUERY_PARAM.COMPANY_NUMBER}}`;

--- a/test/controllers/invalid.company.status.controller.unit.ts
+++ b/test/controllers/invalid.company.status.controller.unit.ts
@@ -1,0 +1,49 @@
+jest.mock("../../src/services/company.profile.service");
+
+import mocks from "../mocks/all.middleware.mock";
+import request from "supertest";
+import app from "../../src/app";
+import { getCompanyProfile } from "../../src/services/company.profile.service";
+import { validCompanyProfile } from "../mocks/company.profile.mock";
+import { INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM } from "../../src/types/page.urls";
+import { urlUtils } from "../../src/utils/url";
+
+const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
+
+const STOP_PAGE_TITLE_COMPANY_STATUS = "You cannot use this service - Company Status";
+const EXPECTED_ERROR_TEXT = "Sorry, the service is unavailable";
+
+describe("Invalid company status controller tests", () => {
+
+  beforeEach(() => {
+    mocks.mockAuthenticationMiddleware.mockClear();
+    mocks.mockServiceAvailabilityMiddleware.mockClear();
+    mocks.mockSessionMiddleware.mockClear();
+    mockGetCompanyProfile.mockClear();
+  });
+
+  describe("get tests", () => {
+
+    it("Should render the invalid company status stop page", async () => {
+      mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
+      const invalidCompanyStatusPath = urlUtils.setQueryParam(INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM.COMPANY_NUMBER, validCompanyProfile.companyNumber);
+
+      const response = await request(app).get(invalidCompanyStatusPath);
+
+      expect(mockGetCompanyProfile).toBeCalledWith(validCompanyProfile.companyNumber);
+      expect(response.text).toContain(STOP_PAGE_TITLE_COMPANY_STATUS);
+      expect(response.text).toContain("dissolved and struck off the register");
+      expect(response.text).toContain(`cannot be filed for ${validCompanyProfile.companyName}`);
+    });
+
+
+    it("Should return an error page if error is thrown in get function", async () => {
+      mockGetCompanyProfile.mockImplementationOnce(() => { throw new Error(); });
+      const invalidCompanyStatusPath = urlUtils.setQueryParam(INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM.COMPANY_NUMBER, validCompanyProfile.companyNumber);
+
+      const response = await request(app).get(invalidCompanyStatusPath);
+
+      expect(response.text).toContain(EXPECTED_ERROR_TEXT);
+    });
+  });
+});

--- a/test/controllers/invalid.company.status.controller.unit.ts
+++ b/test/controllers/invalid.company.status.controller.unit.ts
@@ -11,7 +11,7 @@ import { urlUtils } from "../../src/utils/url";
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 
 const STOP_PAGE_TITLE_COMPANY_STATUS = "You cannot use this service - Company Status";
-const EXPECTED_ERROR_TEXT = "Sorry, the service is unavailable";
+const SERVICE_UNAVAILABLE_TEXT = "Sorry, the service is unavailable";
 
 describe("Invalid company status controller tests", () => {
 
@@ -43,7 +43,7 @@ describe("Invalid company status controller tests", () => {
 
       const response = await request(app).get(invalidCompanyStatusPath);
 
-      expect(response.text).toContain(EXPECTED_ERROR_TEXT);
+      expect(response.text).toContain(SERVICE_UNAVAILABLE_TEXT);
     });
   });
 });


### PR DESCRIPTION
Added new controller for invalid.company.status stop page

Modified the existing confirm.company.controller to create a new map for mapping eligibility codes to redirect paths (need to move from res.render template to redirect to a controller)