### PR TITLE
BI-10494 Add company number query param validation in invalid.company…

### DIFF
--- a/src/controllers/invalid.company.status.controller.ts
+++ b/src/controllers/invalid.company.status.controller.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { getCompanyProfile } from "../services/company.profile.service";
 import { Templates } from "../types/template.paths";
-import { URL_QUERY_PARAM } from "../types/page.urls";
+import { INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM } from "../types/page.urls";
 import { isCompanyNumberValid } from "../validators/company.number.validator";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -10,7 +10,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     const companyNumber = req.query[URL_QUERY_PARAM.COMPANY_NUM] as string;
 
     if (!isCompanyNumberValid(companyNumber)) {
-      return next(new Error("Invalid company number entered in invalid.company.status url query parameter"));
+      return next(new Error(`Invalid company number entered in ${INVALID_COMPANY_STATUS_PATH} url query parameter`));
     }
 
     const company: CompanyProfile = await getCompanyProfile(companyNumber as string);

--- a/src/controllers/invalid.company.status.controller.ts
+++ b/src/controllers/invalid.company.status.controller.ts
@@ -3,10 +3,16 @@ import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/compa
 import { getCompanyProfile } from "../services/company.profile.service";
 import { Templates } from "../types/template.paths";
 import { URL_QUERY_PARAM } from "../types/page.urls";
+import { isCompanyNumberValid } from "../validators/company.number.validator";
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const companyNumber = req.query[URL_QUERY_PARAM.COMPANY_NUM];
+    const companyNumber = req.query[URL_QUERY_PARAM.COMPANY_NUM] as string;
+
+    if (!isCompanyNumberValid(companyNumber)) {
+      return next(new Error("Invalid company number entered in invalid.company.status url query parameter"));
+    }
+
     const company: CompanyProfile = await getCompanyProfile(companyNumber as string);
     return res.render(Templates.INVALID_COMPANY_STATUS, {
       company,

--- a/test/controllers/invalid.company.status.controller.unit.ts
+++ b/test/controllers/invalid.company.status.controller.unit.ts
@@ -53,7 +53,7 @@ describe("Invalid company status controller tests", () => {
 
     it("Should return an error page if invalid company number is entered in url query param", async () => {
       mockIsCompanyNumberValid.mockReturnValueOnce(false);
-      const invalidCompanyStatusPath = urlUtils.setQueryParam(INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM.COMPANY_NUM, validCompanyProfile.companyNumber);
+      const invalidCompanyStatusPath = urlUtils.setQueryParam(INVALID_COMPANY_STATUS_PATH, URL_QUERY_PARAM.COMPANY_NUM, "this is not a valid number");
 
       const response = await request(app).get(invalidCompanyStatusPath);
 


### PR DESCRIPTION
….status.controller

Adding a call to validate the company number that is used in the query param to prevent any other user data being added.
If it is not a valid company number, service throws error and stops the user.