### PR TITLE
BI-10759 removing extra debug from sanitiseReqUrls

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -68,7 +68,6 @@ const sanitiseReqlUrls = (req: Request) => {
   // if they are present and they are longer than allowed length, truncate them.
   for (const urlParamName of Object.values(urlParams)) {
     const urlParamValue = req.params[urlParamName];
-    logger.debug(`sanitising url param ${urlParamName} value ${urlParamValue}`);
     sanitiseParam(req, urlParamName, urlParamValue);
   }
   // loop through the names of the query params in the url and get their values
@@ -76,7 +75,6 @@ const sanitiseReqlUrls = (req: Request) => {
   if (req.query) {
     for (const queryParamName of Object.keys(req.query)) {
       const queryParamValue: string = req.query[queryParamName] as string;
-      logger.debug(`sanitising url query param ${queryParamName} value ${queryParamValue}`);
       sanitiseParam(req, queryParamName, queryParamValue);
     }
   }


### PR DESCRIPTION
Removing a debug statement that I added in the sanitiseReqlUrls. I hadn't truncated the value before logging.
These debugs were redundant anyway as the function called immediately after (sanitiseParam) also debugs out the param name (not value) so removing the extra ones I added.