### PR TITLE
BI-10757 Externalising the validation constants to config file

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,9 +18,6 @@ export const WRONG_DETAILS_UPDATE_OFFICER = "Update the officer details";
 export const WRONG_DETAILS_UPDATE_OFFICERS = "Incorrect Officer Details";
 export const PSC_STATEMENT_NAME_PLACEHOLDER = "{linked_psc_name}";
 export const LOCALE_EN = "en";
-export const URL_LOG_LENGTH = 400;
-export const URL_PARAM_MAX_LENGTH = 50;
-export const RADIO_BUTTON_VALUE_LOG_LENGTH = 50;
 
 export enum RADIO_BUTTON_VALUE {
   NO = "no",

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -40,3 +40,9 @@ export const FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021 = getEnvironmen
 export const PIWIK_START_GOAL_ID = getEnvironmentVariable("PIWIK_START_GOAL_ID");
 
 export const PSC_STATEMENTS_API_PAGE_SIZE = getEnvironmentVariable("PSC_STATEMENTS_API_PAGE_SIZE", "100");
+
+export const URL_LOG_MAX_LENGTH: number = parseInt(getEnvironmentVariable("URL_LOG_MAX_LENGTH", "400"), 10);
+
+export const URL_PARAM_MAX_LENGTH: number = parseInt(getEnvironmentVariable("URL_PARAM_MAX_LENGTH", "50"), 10);
+
+export const RADIO_BUTTON_VALUE_LOG_LENGTH = parseInt(getEnvironmentVariable("RADIO_BUTTON_VALUE_LOG_LENGTH", "50"), 10);

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,7 +1,7 @@
 import { Request } from "express";
 import { urlParams, URL_QUERY_PARAM } from "../types/page.urls";
-import { URL_LOG_LENGTH, URL_PARAM_MAX_LENGTH } from "./constants";
 import { logger } from "./logger";
+import { URL_LOG_MAX_LENGTH, URL_PARAM_MAX_LENGTH } from "./properties";
 
 const getUrlWithCompanyNumber = (url: string, companyNumber: string): string =>
   url.replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, companyNumber);
@@ -33,11 +33,11 @@ const setQueryParam = (url: string, paramName: URL_QUERY_PARAM, value: string) =
 // When using the logger.xxxRequest functions, they will log the full path which
 // might be very large if a malicious url was entered.
 const truncateRequestUrls = (req: Request) => {
-  if (req.originalUrl?.length > URL_LOG_LENGTH) {
-    req.originalUrl = `${req.originalUrl.substring(0, URL_LOG_LENGTH)}...`;
+  if (req.originalUrl?.length > URL_LOG_MAX_LENGTH) {
+    req.originalUrl = `${req.originalUrl.substring(0, URL_LOG_MAX_LENGTH)}...`;
   }
-  if (req.url?.length > URL_LOG_LENGTH) {
-    req.url = `${req.url.substring(0, URL_LOG_LENGTH)}...`;
+  if (req.url?.length > URL_LOG_MAX_LENGTH) {
+    req.url = `${req.url.substring(0, URL_LOG_MAX_LENGTH)}...`;
   }
 };
 

--- a/src/validators/radio.button.validator.ts
+++ b/src/validators/radio.button.validator.ts
@@ -1,5 +1,6 @@
 import { logger } from "../utils/logger";
-import { RADIO_BUTTON_VALUE, RADIO_BUTTON_VALUE_LOG_LENGTH } from "../utils/constants";
+import { RADIO_BUTTON_VALUE } from "../utils/constants";
+import { RADIO_BUTTON_VALUE_LOG_LENGTH } from "../utils/properties";
 
 export const isRadioButtonValueValid = (radioValue: string): boolean => {
   logger.debug("Checking radio button is valid");

--- a/src/validators/url.id.validator.ts
+++ b/src/validators/url.id.validator.ts
@@ -1,4 +1,4 @@
-import { URL_PARAM_MAX_LENGTH } from "../utils/constants";
+import { URL_PARAM_MAX_LENGTH } from "../utils/properties";
 import { logger } from "../utils/logger";
 
 export const isUrlIdValid = (urlId: string): boolean => {

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -11,4 +11,7 @@ export default () => {
   process.env.FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021 = "false";
   process.env.CHS_URL = "http://chs.local";
   process.env.PIWIK_START_GOAL_ID = "3";
+  process.env.URL_LOG_MAX_LENGTH = "400";
+  process.env.URL_PARAM_MAX_LENGTH = "50";
+  process.env.RADIO_BUTTON_VALUE_LOG_LENGTH = "50";
 };

--- a/test/utils/url.unit.ts
+++ b/test/utils/url.unit.ts
@@ -1,6 +1,6 @@
-jest.mock("../../src/utils/constants", () => {
+jest.mock("../../src/utils/properties", () => {
   return {
-    URL_LOG_LENGTH: 100,
+    URL_LOG_MAX_LENGTH: 100,
     URL_PARAM_MAX_LENGTH: 10
   };
 });


### PR DESCRIPTION
Moving the validation constants to environment props aka config file.
Set default values as per the previous constants in case they are missing in config file