### PR TITLE
BI-10593 Adding the validation middleware to the all.middleware.mock …

### DIFF
--- a/test/middleware/company.authentication.middleware.unit.ts
+++ b/test/middleware/company.authentication.middleware.unit.ts
@@ -5,6 +5,10 @@ jest.mock("../../src/validators/company.number.validator");
 import mockSessionMiddleware from "../mocks/session.middleware.mock";
 import mockServiceAvailabilityMiddleware from "../mocks/service.availability.middleware.mock";
 import mockAuthenticationMiddleware from "../mocks/authentication.middleware.mock";
+import mockIsPscQueryParameterValidationMiddleware from "../mocks/is.psc.validation.middleware.mock";
+import mockCompanyNumberQueryParameterValidationMiddleware from "../mocks/company.number.validation.middleware.mock";
+import mockTransactionIdValidationMiddleware from "../mocks/transaction.id.validation.middleware.mock";
+import mockSubmissionIdValidationMiddleware from "../mocks/submission.id.validation.middleware.mock";
 import { authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 import request from "supertest";
 import app from "../../src/app";
@@ -39,6 +43,10 @@ describe("company authentication middleware tests", () => {
     mockSessionMiddleware.mockClear();
     mockServiceAvailabilityMiddleware.mockClear();
     mockAuthenticationMiddleware.mockClear();
+    mockIsPscQueryParameterValidationMiddleware.mockClear();
+    mockCompanyNumberQueryParameterValidationMiddleware.mockClear();
+    mockTransactionIdValidationMiddleware.mockClear();
+    mockSubmissionIdValidationMiddleware.mockClear();
     mockLoggerErrorRequest.mockClear();
   });
 

--- a/test/middleware/submission.id.validation.middleware.unit.ts
+++ b/test/middleware/submission.id.validation.middleware.unit.ts
@@ -3,8 +3,12 @@ jest.mock("../../src/middleware/transaction.id.validation.middleware");
 jest.mock("../../src/services/company.profile.service");
 jest.mock("../../src/utils/logger");
 
-
-import mocks from "../mocks/all.middleware.mock";
+import mockServiceAvailabilityMiddleware from "../mocks/service.availability.middleware.mock";
+import mockAuthenticationMiddleware from "../mocks//authentication.middleware.mock";
+import mockSessionMiddleware from "../mocks/session.middleware.mock";
+import mockCompanyAuthenticationMiddleware from "../mocks/company.authentication.middleware.mock";
+import mockIsPscQueryParameterValidationMiddleware from "../mocks/is.psc.validation.middleware.mock";
+import mockCompanyNumberQueryParameterValidationMiddleware from "../mocks/company.number.validation.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
 import { isUrlIdValid } from "../../src/validators/url.id.validator";
@@ -33,7 +37,12 @@ const SUBMISSION_ID_INVALID = "3223432kjh32kh42342344332443232b32j4jk32h43k2h4k2
 describe("Submission ID validation middleware tests", () => {
 
   beforeEach(() => {
-    mocks.mockAuthenticationMiddleware.mockClear();
+    mockServiceAvailabilityMiddleware.mockClear();
+    mockAuthenticationMiddleware.mockClear();
+    mockSessionMiddleware.mockClear();
+    mockCompanyAuthenticationMiddleware.mockClear();
+    mockIsPscQueryParameterValidationMiddleware.mockClear();
+    mockCompanyNumberQueryParameterValidationMiddleware.mockClear();
     mockIsUrlIdValid.mockClear();
     mockTransactionIdValidationMiddleware.mockClear();
     mockLoggerErrorRequest.mockClear();

--- a/test/middleware/transaction.id.validation.middleware.unit.ts
+++ b/test/middleware/transaction.id.validation.middleware.unit.ts
@@ -3,7 +3,12 @@ jest.mock("../../src/middleware/submission.id.validation.middleware");
 jest.mock("../../src/services/company.profile.service");
 jest.mock("../../src/utils/logger");
 
-import mocks from "../mocks/all.middleware.mock";
+import mockServiceAvailabilityMiddleware from "../mocks/service.availability.middleware.mock";
+import mockAuthenticationMiddleware from "../mocks/authentication.middleware.mock";
+import mockSessionMiddleware from "../mocks/session.middleware.mock";
+import mockCompanyAuthenticationMiddleware from "../mocks/company.authentication.middleware.mock";
+import mockIsPscQueryParameterValidationMiddleware from "../mocks/is.psc.validation.middleware.mock";
+import mockCompanyNumberQueryParameterValidationMiddleware from "../mocks/company.number.validation.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
 import { isUrlIdValid } from "../../src/validators/url.id.validator";
@@ -31,7 +36,12 @@ const TRADING_STATUS_PAGE_HEADING = "Check the trading status";
 describe("Transaction ID validation middleware tests", () => {
 
   beforeEach(() => {
-    mocks.mockAuthenticationMiddleware.mockClear();
+    mockServiceAvailabilityMiddleware.mockClear();
+    mockAuthenticationMiddleware.mockClear();
+    mockCompanyAuthenticationMiddleware.mockClear();
+    mockSessionMiddleware.mockClear();
+    mockIsPscQueryParameterValidationMiddleware.mockClear();
+    mockCompanyNumberQueryParameterValidationMiddleware.mockClear();
     mockIsUrlIdValid.mockClear();
     mockSubmissionIdValidationMiddleware.mockClear();
     mockLoggerErrorRequest.mockClear();

--- a/test/mocks/all.middleware.mock.ts
+++ b/test/mocks/all.middleware.mock.ts
@@ -2,10 +2,18 @@ import mockServiceAvailabilityMiddleware from "./service.availability.middleware
 import mockAuthenticationMiddleware from "./authentication.middleware.mock";
 import mockSessionMiddleware from "./session.middleware.mock";
 import mockCompanyAuthenticationMiddleware from "./company.authentication.middleware.mock";
+import mockSubmissionIdValidationMiddleware from "./submission.id.validation.middleware.mock";
+import mockTransactionIdValidationMiddleware from "./transaction.id.validation.middleware.mock";
+import mockIsPscQueryParameterValidationMiddleware from "./is.psc.validation.middleware.mock";
+import mockCompanyNumberQueryParameterValidationMiddleware from "./company.number.validation.middleware.mock";
 
 export default {
   mockServiceAvailabilityMiddleware,
   mockAuthenticationMiddleware,
   mockSessionMiddleware,
-  mockCompanyAuthenticationMiddleware
+  mockCompanyAuthenticationMiddleware,
+  mockSubmissionIdValidationMiddleware,
+  mockTransactionIdValidationMiddleware,
+  mockIsPscQueryParameterValidationMiddleware,
+  mockCompanyNumberQueryParameterValidationMiddleware
 };

--- a/test/mocks/company.number.validation.middleware.mock.ts
+++ b/test/mocks/company.number.validation.middleware.mock.ts
@@ -1,0 +1,12 @@
+jest.mock("../../src/middleware/company.number.validation.middleware");
+
+import { NextFunction, Request, Response } from "express";
+import { companyNumberQueryParameterValidationMiddleware } from "../../src/middleware/company.number.validation.middleware";
+
+// get handle on mocked function
+const mockCompanyNumberQueryParameterValidationMiddleware = companyNumberQueryParameterValidationMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockCompanyNumberQueryParameterValidationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockCompanyNumberQueryParameterValidationMiddleware;

--- a/test/mocks/is.psc.validation.middleware.mock.ts
+++ b/test/mocks/is.psc.validation.middleware.mock.ts
@@ -1,0 +1,12 @@
+jest.mock("../../src/middleware/is.psc.validation.middleware");
+
+import { NextFunction, Request, Response } from "express";
+import { isPscQueryParameterValidationMiddleware } from "../../src/middleware/is.psc.validation.middleware";
+
+// get handle on mocked function
+const mockIsPscQueryParameterValidationMiddleware = isPscQueryParameterValidationMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockIsPscQueryParameterValidationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockIsPscQueryParameterValidationMiddleware;

--- a/test/mocks/submission.id.validation.middleware.mock.ts
+++ b/test/mocks/submission.id.validation.middleware.mock.ts
@@ -1,0 +1,12 @@
+jest.mock("../../src/middleware/submission.id.validation.middleware");
+
+import { NextFunction, Request, Response } from "express";
+import { submissionIdValidationMiddleware } from "../../src/middleware/submission.id.validation.middleware";
+
+// get handle on mocked function
+const mockSubmissionIdValidationMiddleware = submissionIdValidationMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockSubmissionIdValidationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockSubmissionIdValidationMiddleware;

--- a/test/mocks/transaction.id.validation.middleware.mock.ts
+++ b/test/mocks/transaction.id.validation.middleware.mock.ts
@@ -1,0 +1,12 @@
+jest.mock("../../src/middleware/transaction.id.validation.middleware");
+
+import { NextFunction, Request, Response } from "express";
+import { transactionIdValidationMiddleware } from "../../src/middleware/transaction.id.validation.middleware";
+
+// get handle on mocked function
+const mockTransactionIdValidationMiddleware = transactionIdValidationMiddleware as jest.Mock;
+
+// tell the mock what to return
+mockTransactionIdValidationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+
+export default mockTransactionIdValidationMiddleware;


### PR DESCRIPTION
…module

The all.middleware.mock module is used by other tests as a convenient way to mock all the middleware.
As we've added new validation middleware, I've also added these to the all.middleware.mock module.

The tests for the middleware themselves have to import the mocks individually so as not to mock themselves. I've added a few mock imports in these to mock other middlewares.