### PR TITLE
BI-10839 Changing the route matchers for submission and transcation i…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,8 @@ app.use(serviceAvailabilityMiddleware);
 //  if auth value is invalid and url has invalid data in it
 app.use(companyNumberQueryParameterValidationMiddleware);
 app.use(isPscQueryParameterValidationMiddleware);
-app.use(`*${urls.CONTAINS_TRANSACTION_ID}`, transactionIdValidationMiddleware);
-app.use(`*${urls.CONTAINS_SUBMISSION_ID}`, submissionIdValidationMiddleware);
+app.use(`*${urls.ACTIVE_SUBMISSION_BASE}`, transactionIdValidationMiddleware);
+app.use(`*${urls.ACTIVE_SUBMISSION_BASE}`, submissionIdValidationMiddleware);
 
 app.use(`${urls.CONFIRMATION_STATEMENT}*`, sessionMiddleware);
 const userAuthRegex = new RegExp("^" + urls.CONFIRMATION_STATEMENT + "/.+");

--- a/test/middleware/submission.id.validation.middleware.unit.ts
+++ b/test/middleware/submission.id.validation.middleware.unit.ts
@@ -29,7 +29,9 @@ const mockLoggerErrorRequest = logger.errorRequest as jest.Mock;
 const TRUNCATED_LENGTH = 50;
 const TRADING_STATUS_PAGE_HEADING = "Check the trading status";
 const COMPANY_NUMBER = "12345678";
+const COMPANY_NUMBER_INVALID = "12345678876888787768886876876876878768876876876876876";
 const TRANSACTION_ID = "111905-476716-457831";
+const TRANSACTION_ID_INVALID = "111905-476716-45783156654645645645645645645654645645645645645645643";
 const SUBMISSION_ID_VALID = "8686876876ds6fds6fsd87f686";
 const SUBMISSION_ID_INVALID = "3223432kjh32kh42342344332443232b32j4jk32h43k2h4k233k2jh43k2h4-h32jhg4j2g4jh23gh4";
 
@@ -74,5 +76,27 @@ describe("Submission ID validation middleware tests", () => {
     expect(isUrlIdValid).toBeCalledWith(SUBMISSION_ID_VALID);
     expect(response.text).toContain(TRADING_STATUS_PAGE_HEADING);
     expect(response.statusCode).toEqual(200);
+  });
+
+  it("Should truncate all invalid ids", async () => {
+    const ERROR_PAGE_TEXT = "Sorry, the service is unavailable";
+    const spyTruncateRequestUrl = jest.spyOn(urlUtils, "sanitiseReqUrls");
+    mockIsUrlIdValid.mockReturnValueOnce(false);
+
+    const urlWithInvalidTransactionIdSubmissionId = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(TRADING_STATUS_PATH, COMPANY_NUMBER_INVALID, TRANSACTION_ID_INVALID, SUBMISSION_ID_INVALID);
+    const response = await request(app).get(urlWithInvalidTransactionIdSubmissionId);
+
+    expect(isUrlIdValid).toBeCalledWith(SUBMISSION_ID_INVALID);
+    expect(spyTruncateRequestUrl).toBeCalledTimes(1);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).not.toContain(COMPANY_NUMBER_INVALID);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).not.toContain(SUBMISSION_ID_INVALID);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).not.toContain(TRANSACTION_ID_INVALID);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).toContain(COMPANY_NUMBER_INVALID.substring(0, TRUNCATED_LENGTH));
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).toContain(TRANSACTION_ID_INVALID.substring(0, TRUNCATED_LENGTH));
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).toContain(SUBMISSION_ID_INVALID.substring(0, TRUNCATED_LENGTH));
+    expect(response.statusCode).toEqual(400);
+    expect(response.text).toContain(ERROR_PAGE_TEXT);
+
+    spyTruncateRequestUrl.mockRestore();
   });
 });

--- a/test/middleware/transaction.id.validation.middleware.unit.ts
+++ b/test/middleware/transaction.id.validation.middleware.unit.ts
@@ -26,9 +26,11 @@ mockSubmissionIdValidationMiddleware.mockImplementation((req: Request, res: Resp
 const mockLoggerErrorRequest = logger.errorRequest as jest.Mock;
 
 const COMPANY_NUMBER = "12345678";
+const COMPANY_NUMBER_INVALID = "12345678123456787576567576576565675657657656757657657657667576576576576";
 const TRANSACTION_ID_VALID = "111905-476716-457831";
 const TRANSACTION_ID_INVALID = "454543543543534-5435435345-34543543545435-435435435435345-345435435345-54355";
 const SUBMISSION_ID = "8686876876ds6fds6fsd87f686";
+const SUBMISSION_ID_INVALID = "8686876876ds6fds6fsd87f686454395743895747543895793485798437598437598437598437598375945435435543";
 const TRUNCATED_LENGTH = 50;
 const TRADING_STATUS_PAGE_HEADING = "Check the trading status";
 
@@ -73,5 +75,27 @@ describe("Transaction ID validation middleware tests", () => {
     expect(isUrlIdValid).toBeCalledWith(TRANSACTION_ID_VALID);
     expect(response.statusCode).toEqual(200);
     expect(response.text).toContain(TRADING_STATUS_PAGE_HEADING);
+  });
+
+  it("Should truncate all invalid ids", async () => {
+    const ERROR_PAGE_TEXT = "Sorry, the service is unavailable";
+    const spyTruncateRequestUrl = jest.spyOn(urlUtils, "sanitiseReqUrls");
+    mockIsUrlIdValid.mockReturnValueOnce(false);
+
+    const urlWithInvalidTransactionIdSubmissionId = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(TRADING_STATUS_PATH, COMPANY_NUMBER_INVALID, TRANSACTION_ID_INVALID, SUBMISSION_ID_INVALID);
+    const response = await request(app).get(urlWithInvalidTransactionIdSubmissionId);
+
+    expect(isUrlIdValid).toBeCalledWith(TRANSACTION_ID_INVALID);
+    expect(spyTruncateRequestUrl).toBeCalledTimes(1);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).not.toContain(COMPANY_NUMBER_INVALID);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).not.toContain(TRANSACTION_ID_INVALID);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).not.toContain(SUBMISSION_ID_INVALID);
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).toContain(COMPANY_NUMBER_INVALID.substring(0, TRUNCATED_LENGTH));
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).toContain(TRANSACTION_ID_INVALID.substring(0, TRUNCATED_LENGTH));
+    expect(mockLoggerErrorRequest.mock.calls[0][1]).toContain(SUBMISSION_ID_INVALID.substring(0, TRUNCATED_LENGTH));
+    expect(response.statusCode).toEqual(400);
+    expect(response.text).toContain(ERROR_PAGE_TEXT);
+
+    spyTruncateRequestUrl.mockRestore();
   });
 });


### PR DESCRIPTION
…d validation to allow access to other url params

https://companieshouse.atlassian.net/browse/BI-10839

This changes the app.use paths for the transaction id and submission id validation to use the full 'active submission base' which includes /company/:companyId/transaction/:transactionId/submission/:submissionId
This was because previously just matching on eg. /transaction/:transactionId  meant that we only had access to the transaction id url param  and if other params were also too long, they wouldn't be truncated (as the truncator searches through the url params but this matcher only included transaction id param)