### PR TITLE
Content changes for confirmation statement part 3

### DIFF
--- a/src/controllers/tasks/active.officers.controller.ts
+++ b/src/controllers/tasks/active.officers.controller.ts
@@ -54,7 +54,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return next(new Error(getRadioButtonInvalidValueErrorMessage(activeOfficerDetailsBtnValue)));
     }
     if (activeOfficerDetailsBtnValue === RADIO_BUTTON_VALUE.YES || activeOfficerDetailsBtnValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
-      await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.CONFIRMED);
+      if (activeOfficerDetailsBtnValue === RADIO_BUTTON_VALUE.YES) {
+        await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.CONFIRMED);
+      } else if (activeOfficerDetailsBtnValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
+        await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.RECENT_FILING);
+      }
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     } else if (activeOfficerDetailsBtnValue === RADIO_BUTTON_VALUE.NO) {
       await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.NOT_CONFIRMED);

--- a/src/controllers/tasks/active.officers.details.controller.ts
+++ b/src/controllers/tasks/active.officers.details.controller.ts
@@ -54,7 +54,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return next(new Error(getRadioButtonInvalidValueErrorMessage(officersDetailsBtnValue)));
     }
     if (officersDetailsBtnValue === RADIO_BUTTON_VALUE.YES || officersDetailsBtnValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
-      await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.CONFIRMED);
+      if (officersDetailsBtnValue === RADIO_BUTTON_VALUE.YES) {
+        await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.CONFIRMED);
+      } else if (officersDetailsBtnValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
+        await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.RECENT_FILING);
+      }
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     } else if (officersDetailsBtnValue === RADIO_BUTTON_VALUE.NO) {
       await sendUpdate(req, SECTIONS.ACTIVE_OFFICER, SectionStatus.NOT_CONFIRMED);

--- a/src/controllers/tasks/active.psc.details.controller.ts
+++ b/src/controllers/tasks/active.psc.details.controller.ts
@@ -65,7 +65,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return next(new Error(getRadioButtonInvalidValueErrorMessage(activePscsButtonValue)));
     }
     if (activePscsButtonValue === RADIO_BUTTON_VALUE.YES || activePscsButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
-      await sendUpdate(req, SECTIONS.PSC, SectionStatus.CONFIRMED);
+      if (activePscsButtonValue === RADIO_BUTTON_VALUE.YES) {
+        await sendUpdate(req, SECTIONS.PSC, SectionStatus.CONFIRMED);
+      } else if (activePscsButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
+        await sendUpdate(req, SECTIONS.PSC, SectionStatus.RECENT_FILING);
+      }
       return res.redirect(getPscStatementUrl(req, true));
     } else if (activePscsButtonValue === RADIO_BUTTON_VALUE.NO) {
       await sendUpdate(req, SECTIONS.PSC, SectionStatus.NOT_CONFIRMED);

--- a/src/controllers/tasks/psc.statement.controller.ts
+++ b/src/controllers/tasks/psc.statement.controller.ts
@@ -112,7 +112,7 @@ const getSectionStatusFromButtonValue = (radioButtonValue: RADIO_BUTTON_VALUE): 
   const buttonStatusMap = {
     [RADIO_BUTTON_VALUE.YES]: SectionStatus.CONFIRMED,
     [RADIO_BUTTON_VALUE.NO]: SectionStatus.NOT_CONFIRMED,
-    [RADIO_BUTTON_VALUE.RECENTLY_FILED]: SectionStatus.CONFIRMED
+    [RADIO_BUTTON_VALUE.RECENTLY_FILED]: SectionStatus.RECENT_FILING
   };
   return buttonStatusMap[radioButtonValue];
 };

--- a/src/controllers/tasks/register.locations.controller.ts
+++ b/src/controllers/tasks/register.locations.controller.ts
@@ -45,7 +45,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     if (registerLocationsButton === RADIO_BUTTON_VALUE.YES || registerLocationsButton === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
-      await sendUpdate(req, SECTIONS.REGISTER_LOCATIONS, SectionStatus.CONFIRMED);
+      if (registerLocationsButton === RADIO_BUTTON_VALUE.YES) {
+        await sendUpdate(req, SECTIONS.REGISTER_LOCATIONS, SectionStatus.CONFIRMED);
+      } else if (registerLocationsButton === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
+        await sendUpdate(req, SECTIONS.REGISTER_LOCATIONS, SectionStatus.RECENT_FILING);
+      }
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
 

--- a/src/controllers/tasks/registered.office.address.controller.ts
+++ b/src/controllers/tasks/registered.office.address.controller.ts
@@ -38,7 +38,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return next(new Error(getRadioButtonInvalidValueErrorMessage(roaButtonValue)));
     }
     if (roaButtonValue === RADIO_BUTTON_VALUE.YES || roaButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
-      await sendUpdate(req, SECTIONS.ROA, SectionStatus.CONFIRMED);
+      if (roaButtonValue === RADIO_BUTTON_VALUE.YES) {
+        await sendUpdate(req, SECTIONS.ROA, SectionStatus.CONFIRMED);
+      } else if (roaButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
+        await sendUpdate(req, SECTIONS.ROA, SectionStatus.RECENT_FILING);
+      }
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
 

--- a/src/controllers/tasks/statement.of.capital.controller.ts
+++ b/src/controllers/tasks/statement.of.capital.controller.ts
@@ -63,7 +63,11 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     statementOfCapital.classOfShares = formatTitleCase(statementOfCapital.classOfShares);
 
     if (statementOfCapitalButtonValue === RADIO_BUTTON_VALUE.YES || statementOfCapitalButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
-      await sendUpdate(req, SECTIONS.SOC, SectionStatus.CONFIRMED, statementOfCapital);
+      if (statementOfCapitalButtonValue === RADIO_BUTTON_VALUE.YES) {
+        await sendUpdate(req, SECTIONS.SOC, SectionStatus.CONFIRMED, statementOfCapital);
+      } else if (statementOfCapitalButtonValue === RADIO_BUTTON_VALUE.RECENTLY_FILED) {
+        await sendUpdate(req, SECTIONS.SOC, SectionStatus.RECENT_FILING, statementOfCapital);
+      }
       return res.redirect(urlUtils
         .getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, companyNumber, transactionId, submissionId));
     } else if (statementOfCapitalButtonValue === RADIO_BUTTON_VALUE.NO || !sharesValidation || !totalAmountUnpaidValidation) {

--- a/test/controllers/tasks/active.directors.controller.unit.ts
+++ b/test/controllers/tasks/active.directors.controller.unit.ts
@@ -158,7 +158,7 @@ describe("Active directors controller tests", () => {
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ACTIVE_OFFICER);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
     });
 
     it("Should redisplay active directors page with error when radio button is not selected", async () => {

--- a/test/controllers/tasks/active.officers.details.controller.unit.ts
+++ b/test/controllers/tasks/active.officers.details.controller.unit.ts
@@ -167,7 +167,7 @@ describe("Active officers details controller tests", () => {
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ACTIVE_OFFICER);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
     });
 
     it("Should redisplay active officers details page with error when radio button is not selected", async () => {

--- a/test/controllers/tasks/active.psc.details.controller.unit.ts
+++ b/test/controllers/tasks/active.psc.details.controller.unit.ts
@@ -150,7 +150,7 @@ describe("Active psc details controller tests", () => {
         .send({ psc: RADIO_BUTTON_VALUE.RECENTLY_FILED });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(pscStatementPathWithIsPscParam("true"));
     });

--- a/test/controllers/tasks/psc.statement.controller.unit.ts
+++ b/test/controllers/tasks/psc.statement.controller.unit.ts
@@ -228,7 +228,7 @@ describe("PSC Statement controller tests", () => {
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
     });
 
     it("Should return error page when radio button id is not valid", async () => {

--- a/test/controllers/tasks/register.locations.controller.unit.ts
+++ b/test/controllers/tasks/register.locations.controller.unit.ts
@@ -106,7 +106,7 @@ describe("Register locations controller tests", () => {
       .post(REGISTER_LOCATIONS_URL)
       .send({ registers: RADIO_BUTTON_VALUE.RECENTLY_FILED });
     expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.REGISTER_LOCATIONS);
-    expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+    expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(TASK_LIST_URL);
   });

--- a/test/controllers/tasks/registered.office.address.controller.unit.ts
+++ b/test/controllers/tasks/registered.office.address.controller.unit.ts
@@ -85,7 +85,7 @@ describe("Registered Office Address controller tests", () => {
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(TASK_LIST_URL);
     expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ROA);
-    expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+    expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
   });
 
   it("Should redisplay roa page with error when radio button is not selected", async () => {

--- a/test/controllers/tasks/statement.of.capital.controller.unit.ts
+++ b/test/controllers/tasks/statement.of.capital.controller.unit.ts
@@ -189,7 +189,7 @@ describe("Statement of Capital controller tests", () => {
 
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
     });
 
     it("Should navigate to the statement of capital stop page when the ONLY statement of capital validation has failed.", async () => {

--- a/views/tasks/active-officers-details.html
+++ b/views/tasks/active-officers-details.html
@@ -99,7 +99,7 @@
             }
           },
           {
-            value: "yes",
+            value: "recently_filed",
             text: "No, but an update has been submitted",
             attributes: {
               "data-event-id": "recently-filed-radio-button"

--- a/views/tasks/active-officers-details.html
+++ b/views/tasks/active-officers-details.html
@@ -88,21 +88,21 @@
             value: "yes",
             text: "Yes",
             attributes: {
-              "data-event-id": "yes-radio-button"
+              "data-event-id": "officer-yes-radio-button"
             }
           },
           {
             value: "no",
             text: "No",
             attributes: {
-              "data-event-id": "no-radio-button"
+              "data-event-id": "officer-no-radio-button"
             }
           },
           {
             value: "recently_filed",
             text: "No, but an update has been submitted",
             attributes: {
-              "data-event-id": "recently-filed-radio-button"
+              "data-event-id": "officer-recently-filed-radio-button"
             }
           }
         ]

--- a/views/tasks/active-officers.html
+++ b/views/tasks/active-officers.html
@@ -75,7 +75,7 @@
               }
             },
             {
-              value: "yes",
+              value: "recently_filed",
               text: "No, but an update has been submitted",
               label: "active-officer No, but an update has been submitted",
               attributes: {

--- a/views/tasks/active-psc-details.html
+++ b/views/tasks/active-psc-details.html
@@ -87,7 +87,7 @@
               }
             },
             {
-              value: "yes",
+              value: "recently_filed",
               text: "No, but an update has been submitted",
               attributes: {
                 "data-event-id": "recently-filed-radio-button"

--- a/views/tasks/active-psc-details.html
+++ b/views/tasks/active-psc-details.html
@@ -76,21 +76,21 @@
               value: "yes",
               text: "Yes",
               attributes: {
-                "data-event-id": "yes-radio-button"
+                "data-event-id": "psc-details-yes-radio-button"
               }
             },
             {
               value: "no",
               text: "No",
               attributes: {
-                "data-event-id": "no-radio-button"
+                "data-event-id": "psc-details-no-radio-button"
               }
             },
             {
               value: "recently_filed",
               text: "No, but an update has been submitted",
               attributes: {
-                "data-event-id": "recently-filed-radio-button"
+                "data-event-id": "psc-details-recently-filed-radio-button"
               }
             }
           ]

--- a/views/tasks/people-with-significant-control.html
+++ b/views/tasks/people-with-significant-control.html
@@ -71,7 +71,7 @@
               text: "Yes",
               label: "people-with-significant-control Yes",
               attributes: {
-                "data-event-id": "yes-radio-button"
+                "data-event-id": "psc-yes-radio-button"
               }
             },
             {
@@ -79,7 +79,7 @@
               text: "No",
               label: "people-with-significant-control No",
               attributes: {
-                "data-event-id": "no-radio-button"
+                "data-event-id": "psc-no-radio-button"
               }
             },
             {
@@ -87,7 +87,7 @@
               text: "No, but an update has been submitted",
               label: "people-with-significant-control No, but an update has been submitted",
               attributes: {
-                "data-event-id": "recently-filed-radio-button"
+                "data-event-id": "psc-recently-filed-radio-button"
               }
             }
           ]

--- a/views/tasks/psc-statement.html
+++ b/views/tasks/psc-statement.html
@@ -77,7 +77,7 @@
               text: "Yes",
               label: "psc-statement Yes",
               attributes: {
-                "data-event-id": "yes-radio-button"
+                "data-event-id": "psc-statement-yes-radio-button"
               }
             },
             {
@@ -85,7 +85,7 @@
               text: "No",
               label: "psc-statement No",
               attributes: {
-                "data-event-id": "no-radio-button"
+                "data-event-id": "psc-statement-no-radio-button"
               }
             },
             {
@@ -93,7 +93,7 @@
               text: "No, but an update has been submitted",
               label: "psc-statement No, but an update has been submitted",
               attributes: {
-                "data-event-id": "recently-filed-radio-button"
+                "data-event-id": "psc-statement-recently-filed-radio-button"
               }
             }
           ]

--- a/views/tasks/register-locations.html
+++ b/views/tasks/register-locations.html
@@ -53,21 +53,21 @@
                 value: "yes",
                 text: "Yes",
                 attributes: {
-                  "data-event-id": "yes-radio-button"
+                  "data-event-id": "register-yes-radio-button"
                 }
               },
               {
                 value: "no",
                 text: "No",
                 attributes: {
-                  "data-event-id": "no-radio-button"
+                  "data-event-id": "register-no-radio-button"
                 }
               },
               {
                 value: "recently_filed",
                 text: "No, but an update has been submitted",
                 attributes: {
-                  "data-event-id": "recently-filed-radio-button"
+                  "data-event-id": "register-recently-filed-radio-button"
                 }
               }
             ]

--- a/views/tasks/registered-office-address.html
+++ b/views/tasks/registered-office-address.html
@@ -54,21 +54,21 @@
             value: "yes",
             text: "Yes",
             attributes: {
-              "data-event-id": "yes-radio-button"
+              "data-event-id": "roa-yes-radio-button"
             }
           },
           {
             value: "no",
             text: "No",
             attributes: {
-              "data-event-id": "no-radio-button"
+              "data-event-id": "roa-no-radio-button"
             }
           },
           {
             value: "recently_filed",
             text: "No, but an update has been submitted",
             attributes: {
-              "data-event-id": "recently-filed-radio-button"
+              "data-event-id": "roa-recently-filed-radio-button"
             }
           }
         ]

--- a/views/tasks/registered-office-address.html
+++ b/views/tasks/registered-office-address.html
@@ -65,7 +65,7 @@
             }
           },
           {
-            value: "yes",
+            value: "recently_filed",
             text: "No, but an update has been submitted",
             attributes: {
               "data-event-id": "recently-filed-radio-button"

--- a/views/tasks/shareholders.html
+++ b/views/tasks/shareholders.html
@@ -33,7 +33,12 @@
 
         <h1 class="govuk-heading-xl">Check the shareholder details</h1>
 
-        <h2 class="govuk-heading-m">1 Shareholder</h2>
+        {% if shareholders.length === 1 %}
+          <h2 class="govuk-heading-m">1 shareholder</h2>
+        {% else %}
+          <h2 class="govuk-heading-m">{{shareholders.length}}
+            shareholders</h2>
+        {% endif %}
 
         {% include "includes/shareholders.html" %}
 


### PR DESCRIPTION
[BI-10663](https://companieshouse.atlassian.net/browse/BI-10663): Changed section_status (in confirmation_statement_submissions collection) updates from "confirmed" to "recent_filing" if the "No, but an update has been submitted" button is selected.
[BI-10813](https://companieshouse.atlassian.net/browse/BI-10813): Removed hard-coded header, and replaced it with an if-else block throwing out header depending on the number of shareholders. New header is in lowercase (shareholder/shareholders).