### PR TITLE
Content change PSC review screen

### DIFF
--- a/views/tasks/psc-statement.html
+++ b/views/tasks/psc-statement.html
@@ -45,7 +45,8 @@
           </p>
         {% endset %}
 
-        {% set pscStatementHTML %}
+        <h1 class="govuk-heading-l">Check the PSC statement</h1>
+        {# {% set pscStatementHTML %} #}
           <p class="govuk-body">{{ pscStatement }}</p>
           {{ govukDetails({
             summaryText: "What is a PSC statement?",
@@ -54,7 +55,7 @@
               "data-event-id": "what-are-psc-statements-info"
             }
           }) }}
-        {% endset %}
+        {# {% endset %} #}
 
         {{ govukRadios({
           classes: "govuk-radios",
@@ -67,9 +68,6 @@
               isPageHeading: true,
               classes: "govuk-fieldset__legend--l"
             }
-          },
-          hint: {
-            html: pscStatementHTML
           },
           items: [
             {

--- a/views/tasks/psc-statement.html
+++ b/views/tasks/psc-statement.html
@@ -46,16 +46,14 @@
         {% endset %}
 
         <h1 class="govuk-heading-l">Check the PSC statement</h1>
-        {# {% set pscStatementHTML %} #}
-          <p class="govuk-body">{{ pscStatement }}</p>
-          {{ govukDetails({
-            summaryText: "What is a PSC statement?",
-            html: pscStatementTypesHTML,
-            attributes: {
-              "data-event-id": "what-are-psc-statements-info"
-            }
-          }) }}
-        {# {% endset %} #}
+        <p class="govuk-body">{{ pscStatement }}</p>
+        {{ govukDetails({
+        summaryText: "What is a PSC statement?",
+        html: pscStatementTypesHTML,
+        attributes: {
+            "data-event-id": "what-are-psc-statements-info"
+        }
+        }) }}
 
         {{ govukRadios({
           classes: "govuk-radios",


### PR DESCRIPTION
- Added a header with the text 'Check the PSC statement'.
- Moved the hint text so that it appears between the heading that was just added and the header for the radio buttons.

[BI-11275](https://companieshouse.atlassian.net/browse/BI-11275)