### PR TITLE
Updated section_status for Stop screens

### DIFF
--- a/src/utils/wrong.information.stop.screen.common.web.calls.ts
+++ b/src/utils/wrong.information.stop.screen.common.web.calls.ts
@@ -19,7 +19,7 @@ export const postCommon = async (req: Request, res: Response, next: NextFunction
     }
 
     if (radioButton === RADIO_BUTTON_VALUE.YES) {
-      await sendUpdate(req, sectionName, SectionStatus.CONFIRMED);
+      await sendUpdate(req, sectionName, SectionStatus.RECENT_FILING);
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
 

--- a/test/controllers/incorrect-information/wrong.officer.details.controller.unit.ts
+++ b/test/controllers/incorrect-information/wrong.officer.details.controller.unit.ts
@@ -66,7 +66,7 @@ describe("Wrong officer details stop controller tests", () => {
       const response = await request(app).post(populatedWrongOfficerDetailsPath).send({ radioButton: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ACTIVE_OFFICER);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
     });

--- a/test/controllers/incorrect-information/wrong.psc.details.controller.unit.ts
+++ b/test/controllers/incorrect-information/wrong.psc.details.controller.unit.ts
@@ -66,7 +66,7 @@ describe("Wrong psc details stop controller tests", () => {
       const response = await request(app).post(populatedWrongPscDetailsPath).send({ radioButton: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
     });

--- a/test/controllers/incorrect-information/wrong.psc.statement.controller.unit.ts
+++ b/test/controllers/incorrect-information/wrong.psc.statement.controller.unit.ts
@@ -147,7 +147,7 @@ describe("Wrong psc statement stop controller tests", () => {
         .send({ radioButton: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
     });

--- a/test/controllers/incorrect-information/wrong.registered.office.address.controller.unit.ts
+++ b/test/controllers/incorrect-information/wrong.registered.office.address.controller.unit.ts
@@ -69,7 +69,7 @@ describe("Wrong registered office address stop controller tests", () => {
       const response = await request(app).post(populatedWrongRegisteredOfficeAddressPath).send({ radioButton: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.ROA);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
     });

--- a/test/controllers/incorrect-information/wrong.registers.controller.unit.ts
+++ b/test/controllers/incorrect-information/wrong.registers.controller.unit.ts
@@ -63,7 +63,7 @@ describe("Wrong register locations stop controller tests", () => {
       const response = await request(app).post(populatedWrongRegisterLocationsAddressPath).send({ radioButton: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.REGISTER_LOCATIONS);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(TASK_LIST_URL);
     });


### PR DESCRIPTION
Updated the section_status code sent to Mongo from "Confirmed" to "Recent_Filing" when the Yes radio button is clicked in the Stop screens. Updated respective unit tests accordingly.

[BI-11302](https://companieshouse.atlassian.net/browse/BI-11302)