### PR TITLE
Add Matomo tracking on Yes/No (wrong ROA page)

### DIFF
--- a/views/incorrect-information/wrong-details.html
+++ b/views/incorrect-information/wrong-details.html
@@ -47,11 +47,17 @@
           items: [
             {
               value: "yes",
-              text: "Yes"
+              text: "Yes",
+              attributes: {
+                "data-event-id": "wrong-details-yes-radio-button"
+              }
             },
             {
               value: "no",
-              text: itemText
+              text: itemText,
+              attributes: {
+                "data-event-id": "wrong-details-no-radio-button"
+              }
             }
           ]
         }) }}

--- a/views/incorrect-information/wrong-registers.html
+++ b/views/incorrect-information/wrong-registers.html
@@ -45,11 +45,17 @@
           items: [
             {
               value: "yes",
-              text: "Yes"
+              text: "Yes",
+              attributes: {
+                "data-event-id": "wrong-registers-yes-radio-button"
+              }
             },
             {
               value: "no",
-              text: "No, I do not need to update where the company records are kept"
+              text: "No, I do not need to update where the company records are kept",
+              attributes: {
+                "data-event-id": "wrong-registers-no-radio-button"
+              }
             }
           ]
         }) }}

--- a/views/incorrect-information/wrong-ro.html
+++ b/views/incorrect-information/wrong-ro.html
@@ -33,8 +33,8 @@
       <p>Return to this window after you have made the update.</p>
 
       {{ govukRadios({
-        idPrefix: "wrong-registered-office-address",
-        name: "wrongRegisteredOfficeAddress",
+        idPrefix: "radioButton",
+        name: "radioButton",
         errorMessage: roErrorMsg,
         fieldset: {
           legend: {

--- a/views/incorrect-information/wrong-ro.html
+++ b/views/incorrect-information/wrong-ro.html
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <form action="" method="post">
-      
+
       {% include "includes/error-alert-message.html" %}
       {% if errorMsgText %}
           {% set roErrorMsg = {
@@ -29,12 +29,12 @@
         <a href="{{ changeRoaUrl }}" target="_blank" rel="noopener noreferrer" data-event-id="update-roa-link">update the registered office address (opens in a new tab)</a>
         before you can file a confirmation statement.
       </p>
-      
+
       <p>Return to this window after you have made the update.</p>
 
       {{ govukRadios({
-        idPrefix: "radioButton",
-        name: "radioButton",
+        idPrefix: "wrong-registered-office-address",
+        name: "wrongRegisteredOfficeAddress",
         errorMessage: roErrorMsg,
         fieldset: {
           legend: {
@@ -46,11 +46,17 @@
         items: [
           {
             value: "yes",
-            text: "Yes"
+            text: "Yes",
+            attributes: {
+              "data-event-id": "wrong-roa-yes-radio-button"
+            }
           },
           {
             value: "no",
-            text: "No, I do not need to update the registered office address"
+            text: "No, I do not need to update the registered office address",
+            attributes: {
+              "data-event-id": "wrong-roa-no-radio-button"
+            }
           }
         ]
       }) }}


### PR DESCRIPTION
Add Matomo tracking on Yes/No (wrong <s>ROA</s> MULTPLE pages)

Resolves:

   + Initially:

[BI-11340](https://companieshouse.atlassian.net/browse/BI-11340)
[BI-11363](https://companieshouse.atlassian.net/browse/BI-11363)

   +  plus (by [rgoswami-ch](https://github.com/rgoswami-ch)) :

[BI-11392](https://companieshouse.atlassian.net/browse/BI-11392)
[BI-11393](https://companieshouse.atlassian.net/browse/BI-11393)
[BI-11394](https://companieshouse.atlassian.net/browse/BI-11394)