### PR TITLE
make EWF url a config var

### DIFF
--- a/src/controllers/incorrect-information/wrong.officer.details.controller.ts
+++ b/src/controllers/incorrect-information/wrong.officer.details.controller.ts
@@ -6,9 +6,12 @@ import { WRONG_DETAILS_UPDATE_OFFICERS, DETAIL_TYPE_OFFICER, WRONG_OFFICER_ERROR
 import { SectionStatus } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 import { getRadioButtonInvalidValueErrorMessage, isRadioButtonValueValid } from "../../validators/radio.button.validator";
+import { EWF_URL } from "../../utils/properties";
+
 
 export const get = (req: Request, res: Response) => {
   return res.render(Templates.WRONG_DETAILS, { 
+    EWF_URL,
     templateName: Templates.WRONG_DETAILS,
     backLinkUrl: urlUtils.getUrlToPath(ACTIVE_OFFICERS_DETAILS_PATH, req),
     pageHeading: WRONG_DETAILS_UPDATE_OFFICERS,
@@ -32,6 +35,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
     return res.render(Templates.WRONG_DETAILS, {
+      EWF_URL,
       templateName: Templates.WRONG_DETAILS,
       backLinkUrl: urlUtils.getUrlToPath(ACTIVE_OFFICERS_DETAILS_PATH, req),
       errorMsgText: WRONG_OFFICER_ERROR,

--- a/src/controllers/incorrect-information/wrong.psc.details.controller.ts
+++ b/src/controllers/incorrect-information/wrong.psc.details.controller.ts
@@ -7,9 +7,12 @@ import { WRONG_DETAILS_INCORRECT_PSC, DETAIL_TYPE_PSC_LEGEND, DETAIL_TYPE_PSC, S
 import { SectionStatus } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 import { isRadioButtonValueValid, getRadioButtonInvalidValueErrorMessage } from "../../validators/radio.button.validator";
+import { EWF_URL } from "../../utils/properties";
+
 
 export const get = (req: Request, res: Response) => {
   return res.render(Templates.WRONG_DETAILS, {
+    EWF_URL,
     templateName: Templates.WRONG_DETAILS,
     backLinkUrl: urlUtils.getUrlToPath(ACTIVE_PSC_DETAILS_PATH, req),
     detailType: DETAIL_TYPE_PSC,
@@ -33,7 +36,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
     return res.render(Templates.WRONG_DETAILS, {
-      templateName: Templates.WRONG_DETAILS,
+        EWF_URL,
+        templateName: Templates.WRONG_DETAILS,
         backLinkUrl: urlUtils.getUrlToPath(ACTIVE_PSC_DETAILS_PATH, req),
         detailType: DETAIL_TYPE_PSC,
         detailTypeLegend: DETAIL_TYPE_PSC_LEGEND,

--- a/src/controllers/incorrect-information/wrong.psc.statement.controller.ts
+++ b/src/controllers/incorrect-information/wrong.psc.statement.controller.ts
@@ -9,10 +9,13 @@ import { Session } from "@companieshouse/node-session-handler";
 import { getPscs } from "../../services/psc.service";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 import { isRadioButtonValueValid, getRadioButtonInvalidValueErrorMessage } from "../../validators/radio.button.validator";
+import { EWF_URL } from "../../utils/properties";
+
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
   try {
     return res.render(Templates.WRONG_DETAILS, {
+      EWF_URL,
       templateName: Templates.WRONG_DETAILS,
       backLinkUrl: await getBackLinkUrl(req, res, next),
       detailType: DETAIL_TYPE_PSC,
@@ -39,6 +42,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
     return res.render(Templates.WRONG_DETAILS, {
+      EWF_URL,
       templateName: Templates.WRONG_DETAILS,
       backLinkUrl: await getBackLinkUrl(req, res, next),
       detailType: DETAIL_TYPE_PSC,

--- a/src/controllers/incorrect-information/wrong.registers.controller.ts
+++ b/src/controllers/incorrect-information/wrong.registers.controller.ts
@@ -8,9 +8,12 @@ import { RADIO_BUTTON_VALUE, SECTIONS, WRONG_REGISTER_ERROR } from "../../utils/
 import { SectionStatus } from "@companieshouse/api-sdk-node/dist/services/confirmation-statement";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 import { isRadioButtonValueValid, getRadioButtonInvalidValueErrorMessage } from "../../validators/radio.button.validator";
+import { EWF_URL } from "../../utils/properties";
+
 
 export const get = (req: Request, res: Response) => {
   return res.render(Templates.WRONG_REGISTER_LOCATIONS, {
+    EWF_URL,
     backLinkUrl: urlUtils.getUrlToPath(REGISTER_LOCATIONS_PATH, req),
     taskListUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),
     templateName: Templates.WRONG_REGISTER_LOCATIONS
@@ -32,6 +35,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
       return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
     }
     return res.render(Templates.WRONG_REGISTER_LOCATIONS, {
+      EWF_URL,
       backLinkUrl: urlUtils.getUrlToPath(REGISTER_LOCATIONS_PATH, req),
       taskListUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),
       errorMsgText: WRONG_REGISTER_ERROR,

--- a/src/controllers/incorrect-information/wrong.shareholders.controller.ts
+++ b/src/controllers/incorrect-information/wrong.shareholders.controller.ts
@@ -2,9 +2,12 @@ import { Request, Response } from "express";
 import { urlUtils } from "../../utils/url";
 import { SHAREHOLDERS_PATH } from "../../types/page.urls";
 import { Templates } from "../../types/template.paths";
+import { EWF_URL } from "../../utils/properties";
+
 
 export const get = (req: Request, res: Response) => {
   return res.render(Templates.WRONG_SHAREHOLDERS, {
+    EWF_URL,
     backLinkUrl: urlUtils.getUrlToPath(SHAREHOLDERS_PATH, req),
     templateName: Templates.WRONG_SHAREHOLDERS
   });

--- a/src/controllers/start.controller.ts
+++ b/src/controllers/start.controller.ts
@@ -1,10 +1,11 @@
 import { Request, Response } from "express";
-import { CHS_URL, PIWIK_START_GOAL_ID, FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021 } from "../utils/properties";
+import { CHS_URL, PIWIK_START_GOAL_ID, FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021, EWF_URL } from "../utils/properties";
 import { Templates } from "../types/template.paths";
 
 export const get = (req: Request, res: Response) => {
   return res.render(Templates.START, { CHS_URL,
     PIWIK_START_GOAL_ID,
     FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021,
+    EWF_URL,
     templateName: Templates.START });
 };

--- a/src/controllers/tasks/people.with.significant.control.controller.ts
+++ b/src/controllers/tasks/people.with.significant.control.controller.ts
@@ -21,7 +21,7 @@ import { createAndLogError, logger } from "../../utils/logger";
 import { toReadableFormat } from "../../utils/date";
 import { sendUpdate } from "../../utils/update.confirmation.statement.submission";
 import { formatPSCForDisplay, formatAddressForDisplay } from "../../utils/format";
-import { FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021 } from "../../utils/properties";
+import { FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021, EWF_URL } from "../../utils/properties";
 import { isActiveFeature } from "../../utils/feature.flag";
 import {
   getRadioButtonInvalidValueErrorMessage,
@@ -73,6 +73,7 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
     if (pscButtonValue === RADIO_BUTTON_VALUE.NO) {
       await sendUpdate(req, SECTIONS.PSC, SectionStatus.NOT_CONFIRMED);
       return res.render(Templates.WRONG_DETAILS, {
+        EWF_URL,
         templateName: Templates.WRONG_DETAILS,
         backLinkUrl: urlUtils.getUrlToPath(PEOPLE_WITH_SIGNIFICANT_CONTROL_PATH, req),
         returnToTaskListUrl: urlUtils.getUrlToPath(TASK_LIST_PATH, req),

--- a/src/controllers/tasks/statement.of.capital.controller.ts
+++ b/src/controllers/tasks/statement.of.capital.controller.ts
@@ -19,6 +19,8 @@ import {
   getRadioButtonInvalidValueErrorMessage,
   isRadioButtonValueValid
 } from "../../validators/radio.button.validator";
+import { EWF_URL } from "../../utils/properties";
+
 
 export const get = async(req: Request, res: Response, next: NextFunction) => {
   try {
@@ -33,6 +35,7 @@ export const get = async(req: Request, res: Response, next: NextFunction) => {
     statementOfCapital.classOfShares = formatTitleCase(statementOfCapital.classOfShares);
 
     return res.render(Templates.STATEMENT_OF_CAPITAL, {
+      EWF_URL,
       templateName: Templates.STATEMENT_OF_CAPITAL,
       backLinkUrl: urlUtils
         .getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, companyNumber, transactionId, submissionId),

--- a/src/controllers/trading.stop.controller.ts
+++ b/src/controllers/trading.stop.controller.ts
@@ -2,11 +2,14 @@ import { Request, Response } from "express";
 import { Templates } from "../types/template.paths";
 import { urlUtils } from "../utils/url";
 import { TRADING_STATUS_PATH } from "../types/page.urls";
+import { EWF_URL } from "../utils/properties";
+
 
 export const get = (req: Request, res: Response) => {
 
   return res.render(Templates.TRADING_STOP, {
     backLinkUrl: urlUtils.getUrlToPath(TRADING_STATUS_PATH, req),
+    EWF_URL,
     templateName: Templates.TRADING_STOP
   });
 };

--- a/src/controllers/use.webfiling.controller.ts
+++ b/src/controllers/use.webfiling.controller.ts
@@ -4,7 +4,7 @@ import { getCompanyProfile } from "../services/company.profile.service";
 import { Templates } from "../types/template.paths";
 import { URL_QUERY_PARAM, USE_WEBFILING_PATH } from "../types/page.urls";
 import { isCompanyNumberValid } from "../validators/company.number.validator";
-import { FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021 } from "../utils/properties";
+import { FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021, EWF_URL } from "../utils/properties";
 
 
 export const get = async (req: Request, res: Response, next: NextFunction) => {
@@ -19,6 +19,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     return res.render(Templates.USE_WEBFILING, {
       company,
       FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021,
+      EWF_URL,
       templateName: Templates.USE_WEBFILING
     });
   } catch (e) {

--- a/src/middleware/service.availability.middleware.ts
+++ b/src/middleware/service.availability.middleware.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { SHOW_SERVICE_OFFLINE_PAGE } from "../utils/properties";
+import { SHOW_SERVICE_OFFLINE_PAGE, EWF_URL } from "../utils/properties";
 import { Templates } from "../types/template.paths";
 import { isActiveFeature } from "../utils/feature.flag";
 import { CONFIRMATION_STATEMENT, ACCESSIBILITY_STATEMENT } from "../types/page.urls";
@@ -19,7 +19,7 @@ export const serviceAvailabilityMiddleware = (req: Request, res: Response, next:
   }
 
   if (isActiveFeature(SHOW_SERVICE_OFFLINE_PAGE)) {
-    return res.render(Templates.SERVICE_OFFLINE);
+    return res.render(Templates.SERVICE_OFFLINE, {EWF_URL});
   }
 
   // feature flag SHOW_SERVICE_OFFLINE_PAGE is false - carry on as normal

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -46,3 +46,5 @@ export const URL_LOG_MAX_LENGTH: number = parseInt(getEnvironmentVariable("URL_L
 export const URL_PARAM_MAX_LENGTH: number = parseInt(getEnvironmentVariable("URL_PARAM_MAX_LENGTH", "50"), 10);
 
 export const RADIO_BUTTON_VALUE_LOG_LENGTH = parseInt(getEnvironmentVariable("RADIO_BUTTON_VALUE_LOG_LENGTH", "50"), 10);
+
+export const EWF_URL = getEnvironmentVariable("EWF_URL");

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -14,4 +14,5 @@ export default () => {
   process.env.URL_LOG_MAX_LENGTH = "400";
   process.env.URL_PARAM_MAX_LENGTH = "50";
   process.env.RADIO_BUTTON_VALUE_LOG_LENGTH = "50";
+  process.env.EWF_URL = "https://ewf.companieshouse.gov.uk/";
 };

--- a/views/incorrect-information/wrong-details.html
+++ b/views/incorrect-information/wrong-details.html
@@ -26,7 +26,7 @@
           You need to update the company details
         </h1>
         <p>You will need to update the {{detailType}} details on our 
-          <a href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-link" target="_blank" rel="noopener noreferrer">WebFiling service (opens in a new tab)</a>
+          <a href="{{EWF_URL}}" data-event-id="webfiling-link" target="_blank" rel="noopener noreferrer">WebFiling service (opens in a new tab)</a>
           before you can file a confirmation statement.</p>
         
         <p>Return to this window after you have made the update.</p>

--- a/views/incorrect-information/wrong-registers.html
+++ b/views/incorrect-information/wrong-registers.html
@@ -26,7 +26,7 @@
           You need to update the company details
         </h1>
         <p>You will need to update where the company records are kept on our 
-          <a target="_blank" href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" rel="noopener noreferrer" data-event-id="webfiling-link">WebFiling service (opens in a new tab)</a>
+          <a target="_blank" href="{{EWF_URL}}" rel="noopener noreferrer" data-event-id="webfiling-link">WebFiling service (opens in a new tab)</a>
            before you can file a confirmation statement.</p>
         
         <p>Return to this window after you have made the update.</p>

--- a/views/incorrect-information/wrong-shareholders.html
+++ b/views/incorrect-information/wrong-shareholders.html
@@ -14,7 +14,7 @@
           You cannot use this service
         </h1>
         <p>Currently, changes to shareholder details can only be made by filing a confirmation statement through
-          <a target="_blank" rel="noopener noreferrer" href="https://ewf.companieshouse.gov.uk//seclogin?tc=1">our WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.
+          <a target="_blank" rel="noopener noreferrer" href="{{EWF_URL}}">our WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.
         </p>
         <p>
             <a href="https://www.smartsurvey.co.uk/s/fileconfstmnt-wrongsharesholders/">What did you think of this service?</a>

--- a/views/incorrect-information/wrong-sic.html
+++ b/views/incorrect-information/wrong-sic.html
@@ -14,7 +14,7 @@
           You cannot use this service
         </h1>
         <p>You must update this information by filing a confirmation statement through our 
-          <a target="_blank" rel="noopener noreferrer" href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.
+          <a target="_blank" rel="noopener noreferrer" href="{{EWF_URL}}" data-event-id="webfiling-service-link">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.
         </p>
         <p>
             <a href="https://www.smartsurvey.co.uk/s/fileconfstmnt-wrongsiccode/">What did you think of this service?</a>

--- a/views/incorrect-information/wrong-statement-of-capital.html
+++ b/views/incorrect-information/wrong-statement-of-capital.html
@@ -27,11 +27,11 @@
           {% endif %}
 
           <p>You must update this information by filing a confirmation statement through our 
-            <a target="_blank" rel="noopener noreferrer" href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link-from-invalid-share-or-amount-unpaid-totals-wrong-statement-of-capital-page">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.</p>
+            <a target="_blank" rel="noopener noreferrer" href="{{EWF_URL}}" data-event-id="webfiling-service-link-from-invalid-share-or-amount-unpaid-totals-wrong-statement-of-capital-page">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.</p>
 
         {% else %}
           <p>You must update this information by filing a confirmation statement through our 
-            <a target="_blank" rel="noopener noreferrer" href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link-from-wrong-statement-of-capital-page">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.
+            <a target="_blank" rel="noopener noreferrer" href="{{EWF_URL}}" data-event-id="webfiling-service-link-from-wrong-statement-of-capital-page">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.
           </p>
         {% endif %}
         <p><a href="https://www.smartsurvey.co.uk/s/fileconfstmnt-wrongsharecap/">What did you think of this service?</a> (takes 2 minutes)</p>

--- a/views/service-offline.html
+++ b/views/service-offline.html
@@ -12,7 +12,7 @@
       <p class="govuk-body-m">You will be able to use the service at a later date.</p>
 
       {% set fileByPostHTML %}
-      <p>You can file a confirmation statement online using our <a href="https://ewf.companieshouse.gov.uk//seclogin?tc=1">WebFiling service</a>.</p>
+      <p>You can file a confirmation statement online using our <a href="{{EWF_URL}}">WebFiling service</a>.</p>
       <p>You can also file a confirmation statement by post using the <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01">CS01 paper form</a>. It costs £40 and will take longer than if you file online.</p>
       <p>There are separate paper forms for:</p>
       <ul class="govuk-list govuk-list--bullet">

--- a/views/start.html
+++ b/views/start.html
@@ -46,7 +46,7 @@
 
       </ul>
       <p>If the company does not meet these criteria, you will need to file a confirmation statement using our
-        <a href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link-from-ncs-start-page">WebFiling service</a>.</p>
+        <a href="{{EWF_URL}}" data-event-id="webfiling-service-link-from-ncs-start-page">WebFiling service</a>.</p>
 
       <p>You cannot use this service to make any changes to company information. You should
         <a href="{{CHS_URL}}" data-event-id="check-company-details-link">check the company's details</a>

--- a/views/tasks/statement-of-capital.html
+++ b/views/tasks/statement-of-capital.html
@@ -39,7 +39,7 @@
               {% set warningHTML %}
                 <p><strong>You cannot continue to file a confirmation statement in this service.</strong></p>
                 <p><strong>The company's share capital does not match the number of shares held by its shareholders.</strong></p>
-                <p><strong>You must update this information by filing a confirmation statement through our <a href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link-from-statement-of-capital-page">WebFiling service</a>.</strong></p>
+                <p><strong>You must update this information by filing a confirmation statement through our <a href="{{EWF_URL}}" data-event-id="webfiling-service-link-from-statement-of-capital-page">WebFiling service</a>.</strong></p>
               {% endset %}
 
               {{ govukWarningText({
@@ -52,7 +52,7 @@
               {% set warningHTML %}
                 <p><strong>You cannot continue to file a confirmation statement in this service.</strong></p>
                 <p><strong>The total amount unpaid for all shares is missing on this company’s statement of capital.</strong></p>
-                <p><strong>You must update this information by filing a confirmation statement through our <a href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link-from-statement-of-capital-page">WebFiling service</a>.</strong></p>
+                <p><strong>You must update this information by filing a confirmation statement through our <a href="{{EWF_URL}}" data-event-id="webfiling-service-link-from-statement-of-capital-page">WebFiling service</a>.</strong></p>
               {% endset %}
 
               {{ govukWarningText({

--- a/views/trading-stop.html
+++ b/views/trading-stop.html
@@ -16,7 +16,7 @@
           You cannot use this service
         </h1>
         <p>You must update this information by filing a confirmation statement through our 
-          <a target="_blank" rel="noopener noreferrer" href="https://ewf.companieshouse.gov.uk//seclogin?tc=1" data-event-id="webfiling-service-link-from-trading-status-stop-screen" target="_blank" rel="noopener noreferrer">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.</p>
+          <a target="_blank" rel="noopener noreferrer" href="{{EWF_URL}}" data-event-id="webfiling-service-link-from-trading-status-stop-screen" target="_blank" rel="noopener noreferrer">WebFiling service (opens in a new tab)</a>. You will need to sign in to or create a WebFiling account to do this.</p>
         <p><a href="https://www.smartsurvey.co.uk/s/fileconfstmnt-wrongsharecap/">What did you think of this service?</a> (takes 2 minutes)</p>
       </form>
     </div>

--- a/views/use-webfiling.html
+++ b/views/use-webfiling.html
@@ -30,7 +30,7 @@
       </ul>
 
       <p>You will need to use
-        <a href="https://ewf.companieshouse.gov.uk//seclogin?tc=1">our Webfiling service</a> to file a confirmation statement for this company.
+        <a href="{{EWF_URL}}">our Webfiling service</a> to file a confirmation statement for this company.
         <p>
             <a href="https://www.smartsurvey.co.uk/s/fileconfstmnt-mvpdoesntsupport/">What did you think of this service?</a>
             (takes 2 minutes)</p>


### PR DESCRIPTION
Resolves:
https://companieshouse.atlassian.net/browse/BI-11403

Strip out `//seclogin?tc=1`
from EWF url, plus make it a config var
so that any change is just sourced via app_env
instead of needing a rebuild of 10 templates with a new artefact.

Linked to
https://github.com/companieshouse/chs-configs/pull/1949