### PR TITLE
Bugfix incorrect checked status

### DIFF
--- a/src/controllers/tasks/active.psc.details.controller.ts
+++ b/src/controllers/tasks/active.psc.details.controller.ts
@@ -1,4 +1,4 @@
-import e, { NextFunction, Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import {
   PSC_STATEMENT_PATH,
   TASK_LIST_PATH,

--- a/test/controllers/tasks/active.psc.details.controller.unit.ts
+++ b/test/controllers/tasks/active.psc.details.controller.unit.ts
@@ -139,7 +139,7 @@ describe("Active psc details controller tests", () => {
         .send({ psc: RADIO_BUTTON_VALUE.YES });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.CONFIRMED);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.NOT_CONFIRMED);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(pscStatementPathWithIsPscParam("true"));
     });
@@ -150,7 +150,7 @@ describe("Active psc details controller tests", () => {
         .send({ psc: RADIO_BUTTON_VALUE.RECENTLY_FILED });
 
       expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.PSC);
-      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.RECENT_FILING);
+      expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.NOT_CONFIRMED);
       expect(response.status).toEqual(302);
       expect(response.header.location).toEqual(pscStatementPathWithIsPscParam("true"));
     });


### PR DESCRIPTION
Changed `active.psc.details.controller` so that it doesn't `CHECKED` status until the user has completed the following screen. If the user uses the back button to go back to the task list after making a selection on the first screen, the status will now show `READ TO CONTINUE`.

Resolves: [BI-11341](https://companieshouse.atlassian.net/browse/BI-11341)