### PR TITLE
Signout - Add signout to confirmation screen

### DIFF
--- a/src/controllers/confirmation.controller.ts
+++ b/src/controllers/confirmation.controller.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { Templates } from "../types/template.paths";
 import { urlUtils } from "../utils/url";
 import { Session } from "@companieshouse/node-session-handler";
+import { ACCOUNTS_SIGNOUT_PATH } from "../types/page.urls";
 
 export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -9,6 +10,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
     const session = req.session as Session;
     const userEmail = session.data.signin_info?.user_profile?.email;
     return res.render(Templates.CONFIRMATION, {
+      signoutURL: ACCOUNTS_SIGNOUT_PATH,
       referenceNumber: transactionId,
       userEmail
     });

--- a/views/confirmation.html
+++ b/views/confirmation.html
@@ -4,10 +4,6 @@
 Confirmation
 {% endblock %}
 
-{% block signoutBar %}
-{# Remove signout bar on this page by replacing it with nothing #}
-{% endblock %}
-
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/views/includes/signout-bar.html
+++ b/views/includes/signout-bar.html
@@ -1,0 +1,10 @@
+{% if userEmail %}
+    {% set signoutURL = signoutURL | default("/confirmation-statement/signout") %}
+    {% set email = userEmail | default("Not signed in") %}
+    <ul class="js-signout" id="navigation">
+        <li class="content-email" id="signed-in-user">{{email}}</li>
+        <li class="content">
+        <a href="{{signoutURL}}" id="user-signout">Sign out</a>
+        </li>
+    </ul>
+{% endif %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -58,15 +58,7 @@
   }) }}
 
   {% block signoutBar %}
-    {% if userEmail %}
-        {% set email = userEmail | default("Not signed in") %}
-        <ul class="js-signout" id="navigation">
-            <li class="content-email" id="signed-in-user">{{email}}</li>
-            <li class="content">
-            <a href="/confirmation-statement/signout" id="user-signout">Sign out</a>
-            </li>
-        </ul>
-    {% endif %}
+    {% include "includes/signout-bar.html" %}
   {% endblock %}
 
   {% block backLink %}


### PR DESCRIPTION
Added signout bar to confirmation screen. 
Added configuration to signout bar to allow signout url to change.
In the confirmation controller, set the signoutURL so that the signout cofirmation screen is by passed. 

Addition to [BI-11289](https://companieshouse.atlassian.net/browse/BI-11289)