### PR TITLE
changes to signout bar and layout for timeout

### DIFF
--- a/views/includes/signout-bar.html
+++ b/views/includes/signout-bar.html
@@ -7,4 +7,5 @@
         <a href="{{signoutURL}}" data-event-id="signout" id="user-signout">Sign out</a>
         </li>
     </ul>
+    <script src="{{assetPath}}/javascripts/app/session-timeout.js"></script>
 {% endif %}

--- a/views/layout.html
+++ b/views/layout.html
@@ -17,6 +17,7 @@
 
   <link href="{{assetPath}}/stylesheets/services/confirmation-statement/application.css" rel="stylesheet" />
 
+  <link href="{{assetPath}}/stylesheets/session-timeout.css" rel="stylesheet" />
   <!--[if !IE 8]><!-->
   <link href="{{assetPath}}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css" rel="stylesheet" />
   <!--<![endif]-->


### PR DESCRIPTION
Added the CSS stylesheet to the layout.html.

Added the JavaScript file to the signout-bar.html, so that the users are only timed out if they are signed in.

Resolves:

- BI-12077