### PR TITLE
Bump node session handler version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/companieshouse/confirmation-statement-web#readme",
   "dependencies": {
     "@companieshouse/api-sdk-node": "^1.0.89",
-    "@companieshouse/node-session-handler": "^4.1.6",
+    "@companieshouse/node-session-handler": "^4.1.7",
     "@companieshouse/structured-logging-node": "^1.0.4",
     "@companieshouse/web-security-node": "^2.0.0",
     "cookie-parser": "^1.4.6",


### PR DESCRIPTION
This PR sets the node session handler to the latest version which refreshes the cookie whenever a request is sent. This is to stop the session from timing out even when the user is performing actions after the new session timeout is implemented.

**Resolves:**
- BI-12511