### PR TITLE
Use SECTION.EMAIL for all email status updates

### DIFF
--- a/src/controllers/tasks/confirm.email.address.controller.ts
+++ b/src/controllers/tasks/confirm.email.address.controller.ts
@@ -23,7 +23,7 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    await sendUpdate(req, SECTIONS.REA, SectionStatus.INITIAL_FILING);
+    await sendUpdate(req, SECTIONS.EMAIL, SectionStatus.INITIAL_FILING);
     return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
   } catch (error) {
     return next(error);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -58,7 +58,6 @@ export enum SECTIONS {
   ACTIVE_OFFICER = "activeOfficerDetailsData",
   EMAIL = "registeredEmailAddressData",
   PSC = "personsSignificantControlData",
-  REA = "registeredEmailAddressData",
   ROA = "registeredOfficeAddressData",
   REGISTER_LOCATIONS = "registerLocationsData",
   SIC = "sicCodeData",

--- a/test/controllers/tasks/confirm.email.address.controller.unit.ts
+++ b/test/controllers/tasks/confirm.email.address.controller.unit.ts
@@ -38,7 +38,7 @@ describe("Confirm Email Address controller tests", () => {
 
   it("Should return to task list page when email address is confirmed", async () => {
     const response = await request(app).post(CONFIRM_EMAIL_ADDRESS_URL);
-    expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.REA);
+    expect(mockSendUpdate.mock.calls[0][1]).toBe(SECTIONS.EMAIL);
     expect(mockSendUpdate.mock.calls[0][2]).toBe(SectionStatus.INITIAL_FILING);
     expect(response.status).toEqual(302);
     expect(response.header.location).toEqual(TASK_LIST_URL);


### PR DESCRIPTION
Two parallel pieces of work added different constants with the same value - switching to use EMAIL consistently and removing REA.