### PR TITLE
Feature/ecct 813 capture first time email in request body to confirmation statement api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.135",
+        "@companieshouse/api-sdk-node": "^2.0.137",
         "@companieshouse/node-session-handler": "^4.1.9",
         "@companieshouse/structured-logging-node": "^1.0.8",
         "@companieshouse/web-security-node": "^2.0.0",
@@ -786,9 +786,9 @@
       "dev": true
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.135",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.135.tgz",
-      "integrity": "sha512-izoXNsOzk4/dvqZncAIqaN8dXY3Q4QnxqDnWjneKf7He23OVdNQTwi/wJZ8gGbon+MAQlTzg0kqbomdaojCDmw==",
+      "version": "2.0.137",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.137.tgz",
+      "integrity": "sha512-KZ54VIWFlPrutrlGn0W5oWjY5kgGfc68P0f+mMg1KB/LBO1aMULJ96KDfWI+UiZ7ZfXt5kVaQteoGiqRp5eSUg==",
       "dependencies": {
         "axios": "^1.6.1",
         "camelcase-keys": "~6.2.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/companieshouse/confirmation-statement-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.135",
+    "@companieshouse/api-sdk-node": "^2.0.137",
     "@companieshouse/node-session-handler": "^4.1.9",
     "@companieshouse/structured-logging-node": "^1.0.8",
     "@companieshouse/web-security-node": "^2.0.0",

--- a/src/controllers/tasks/confirm.email.address.controller.ts
+++ b/src/controllers/tasks/confirm.email.address.controller.ts
@@ -11,10 +11,10 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
   try {
     const session = req.session as Session;
     const backLinkUrl = urlUtils.getUrlToPath(PROVIDE_EMAIL_ADDRESS_PATH, req);
-    const emailAddress = session.getExtraData("entered-email-address");
+    const confirmEmailAddress = session.getExtraData("entered-email-address");
     return res.render(Templates.CONFIRM_EMAIL_ADDRESS, {
       templateName: Templates.CONFIRM_EMAIL_ADDRESS,
-      backLinkUrl, emailAddress
+      backLinkUrl, confirmEmailAddress
     });
   } catch (error) {
     return next(error);
@@ -22,8 +22,10 @@ export const get = (req: Request, res: Response, next: NextFunction) => {
 };
 
 export const post = async (req: Request, res: Response, next: NextFunction) => {
+  const session = req.session as Session;
+  const confirmEmailAddress = session.getExtraData("entered-email-address");
   try {
-    await sendUpdate(req, SECTIONS.EMAIL, SectionStatus.INITIAL_FILING);
+    await sendUpdate(req, SECTIONS.EMAIL, SectionStatus.INITIAL_FILING, confirmEmailAddress);
     return res.redirect(urlUtils.getUrlToPath(TASK_LIST_PATH, req));
   } catch (error) {
     return next(error);

--- a/src/utils/update.confirmation.statement.submission.ts
+++ b/src/utils/update.confirmation.statement.submission.ts
@@ -2,6 +2,7 @@ import { Request } from "express";
 import { Session } from "@companieshouse/node-session-handler";
 import {
   ConfirmationStatementSubmission,
+  RegisteredEmailAddressData,
   SectionStatus,
   StatementOfCapitalData,
   TradingStatusData
@@ -15,8 +16,8 @@ export const sendUpdate = async (req: Request, sectionName: SECTIONS, status: Se
   const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
   const session = req.session as Session;
   const currentCsSubmission: ConfirmationStatementSubmission = await getConfirmationStatement(session, transactionId, submissionId);
-  const sectionData = generateSectionData(sectionName, status, extraData);
-  const csSubmission = updateCsSubmission(currentCsSubmission, sectionName, sectionData);
+  const additionalData = generateAdditionalData(sectionName, status, extraData);
+  const csSubmission = updateCsSubmission(currentCsSubmission, sectionName, additionalData);
   await updateConfirmationStatement(session, transactionId, submissionId, csSubmission);
 };
 
@@ -37,7 +38,7 @@ const updateCsSubmission = (currentCsSubmission: ConfirmationStatementSubmission
   return currentCsSubmission;
 };
 
-const generateSectionData = (section: SECTIONS, status: SectionStatus, extraData?: any): any => {
+const generateAdditionalData = (section: SECTIONS, status: SectionStatus, extraData?: any): any => {
   switch (section) {
       case SECTIONS.SOC: {
         const newSocData: StatementOfCapitalData = {
@@ -48,6 +49,17 @@ const generateSectionData = (section: SECTIONS, status: SectionStatus, extraData
         }
         return newSocData;
       }
+
+      case SECTIONS.EMAIL: {
+         const newEmailData: RegisteredEmailAddressData = {
+           sectionStatus: status
+         };
+         if (extraData) {
+           newEmailData.registeredEmailAddress = extraData;
+         }
+         return newEmailData;
+       }
+
       default: {
         return {
           sectionStatus: status,

--- a/views/tasks/confirm-email-address.html
+++ b/views/tasks/confirm-email-address.html
@@ -16,7 +16,7 @@
       <h1 class="govuk-heading-l">Check the email address</h1>
         <dl>
           <dt class="govuk-summary-list__key">Email address</dt>
-          <dd class="govuk-summary-list__value">{{ emailAddress }}</dd>
+          <dd class="govuk-summary-list__value"> {{ confirmEmailAddress }} </dd>
           <dd class="govuk-summary-list__value govuk-!-padding-left-3"><a href="{{backLinkUrl}}">Change</a></dd>
         </dl>
       <br>


### PR DESCRIPTION
### JIRA link

https://companieshouse.atlassian.net/browse/ECCT-813

### Change description

Send updated confirmation statement with additional email data to confirmation-statement-api service.
The registered email address is sent with the section status in the request body to the api.

Additional PR for the api-sdk-node changes here:
https://github.com/companieshouse/api-sdk-node/pull/641

### Work checklist

- [x] Tests added where applicable