### PR TITLE
Update paper fee amount & paper form url [BI-13955]

### DIFF
--- a/views/includes/other-ways-to-file.html
+++ b/views/includes/other-ways-to-file.html
@@ -1,6 +1,6 @@
 {% set fileByPostHTML %}
 <p>You can file a confirmation statement online using our <a href="{{EWF_URL}}">WebFiling service</a>.</p>
-<p>You can also file a confirmation statement by post using the <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01">CS01 paper form</a>. It costs £62 and will take longer than if you file online.</p>
+<p>You can also file a confirmation statement by post using the <a href="https://www.gov.uk/government/publications/confirmation-statement-form-cs01-new-version">CS01 paper form</a>. It costs £62 and will take longer than if you file online.</p>
 <p>There are separate paper forms for:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-limited-liability-partnership-ll-cs01">limited liability partnerships - LLCS01</a></li>

--- a/views/includes/other-ways-to-file.html
+++ b/views/includes/other-ways-to-file.html
@@ -1,6 +1,6 @@
 {% set fileByPostHTML %}
 <p>You can file a confirmation statement online using our <a href="{{EWF_URL}}">WebFiling service</a>.</p>
-<p>You can also file a confirmation statement by post using the <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01">CS01 paper form</a>. It costs £40 and will take longer than if you file online.</p>
+<p>You can also file a confirmation statement by post using the <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01">CS01 paper form</a>. It costs £62 and will take longer than if you file online.</p>
 <p>There are separate paper forms for:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li><a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-limited-liability-partnership-ll-cs01">limited liability partnerships - LLCS01</a></li>

--- a/views/paper-filing.html
+++ b/views/paper-filing.html
@@ -17,7 +17,7 @@
         {% elseif company.type === "scottish-partnership" %}
           <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01"/>SQP CSO1 confirmation statement paper form</a>.
         {% else %}
-           <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01" data-event-id="confirmation-statement-paper-form-link">CS01 confirmation statement paper form</a>.
+           <a href="https://www.gov.uk/government/publications/confirmation-statement-form-cs01-new-version" data-event-id="confirmation-statement-paper-form-link">CS01 confirmation statement paper form</a>.
         {% endif %}
 
         This can be submitted online using our <a href="https://find-and-update.company-information.service.gov.uk/efs-submission/start" data-event-id="upload-a-document-link">Upload a document to Companies House</a> service.</p>

--- a/views/start.html
+++ b/views/start.html
@@ -22,7 +22,7 @@
 
       {% set fileByPostHTML %}
         <p>You can also file a confirmation statement by post using the
-        <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01" data-event-id="CS01-paper-form-link">CS01 paper form</a>. It costs £62 and will take longer to process than if you file online.</p>
+        <a href="https://www.gov.uk/government/publications/confirmation-statement-form-cs01-new-version" data-event-id="CS01-paper-form-link">CS01 paper form</a>. It costs £62 and will take longer to process than if you file online.</p>
       {% endset %}
 
       {% set insetHTML %}

--- a/views/start.html
+++ b/views/start.html
@@ -22,7 +22,7 @@
 
       {% set fileByPostHTML %}
         <p>You can also file a confirmation statement by post using the
-        <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01" data-event-id="CS01-paper-form-link">CS01 paper form</a>. It costs £40 and will take longer to process than if you file online.</p>
+        <a href="https://www.gov.uk/government/publications/confirmation-statement-cs01" data-event-id="CS01-paper-form-link">CS01 paper form</a>. It costs £62 and will take longer to process than if you file online.</p>
       {% endset %}
 
       {% set insetHTML %}


### PR DESCRIPTION
Update paper fee amount from £40 to £62 (in service unavailable page as well as start page).
Also update all instances of paper form link (start page, service unavailable page, paper filing page) to point to post-ECCT version.