### PR TITLE
SEC-113 Upgrade web security node module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@companieshouse/api-sdk-node": "^2.0.147",
         "@companieshouse/node-session-handler": "^5.0.1",
         "@companieshouse/structured-logging-node": "^2.0.1",
-        "@companieshouse/web-security-node": "^4.3.1",
+        "@companieshouse/web-security-node": "^4.4.0",
         "cookie-parser": "^1.4.6",
         "express": "^4.17.1",
         "govuk-frontend": "^3.14.0",
@@ -822,9 +822,9 @@
       }
     },
     "node_modules/@companieshouse/web-security-node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.3.1.tgz",
-      "integrity": "sha512-sQhbApcY5a5K8eSHdnPDiyY5q4DiMF/j6Q3tsaHx4yJs5264JDk3aFcPr0ZhcePBB7kVnekGg1idvPdN0TZcvQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.0.tgz",
+      "integrity": "sha512-JF7Oi+ljrVLhpkGgQdN4tV58IDw1Vn41wtYJxD+QkyVq5Ll+/W8RtcCR8Sdc2ugiDqd3DpxqGWyt9fhIRz4iyQ==",
       "dependencies": {
         "@companieshouse/node-session-handler": "~5.1.3",
         "@companieshouse/structured-logging-node": "~2.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@companieshouse/api-sdk-node": "^2.0.147",
     "@companieshouse/node-session-handler": "^5.0.1",
     "@companieshouse/structured-logging-node": "^2.0.1",
-    "@companieshouse/web-security-node": "^4.3.1",
+    "@companieshouse/web-security-node": "^4.4.0",
     "cookie-parser": "^1.4.6",
     "express": "^4.17.1",
     "govuk-frontend": "^3.14.0",


### PR DESCRIPTION
Problems with pipeline deployment to cidev, error found int he logs:

"Could not handle CSRF validation: TypeError: Cannot read properties of undefined (reading 'length')"

Similar problem found in registered email address: https://github.com/companieshouse/registered-email-address-web/pull/177/files

So applied the same upgrade fix here.