### PR TITLE
CSE-785 Submit Confirmation Statement Back Button

### DIFF
--- a/test/controllers/review.controller.unit.ts
+++ b/test/controllers/review.controller.unit.ts
@@ -11,7 +11,7 @@ import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transact
 import request from "supertest";
 import mocks from "../mocks/all.middleware.mock";
 import app from "../../src/app";
-import { CONFIRMATION_PATH, REVIEW_PATH } from "../../src/types/page.urls";
+import { CONFIRMATION_PATH, LP_CHECK_YOUR_ANSWER_PATH, LP_CS_DATE_PATH, LP_SIC_CODE_SUMMARY_PATH, REVIEW_PATH, urlParams } from '../../src/types/page.urls';
 import { urlUtils } from "../../src/utils/url";
 import { validCompanyProfile } from "../mocks/company.profile.mock";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
@@ -22,6 +22,8 @@ import { createAndLogError } from "../../src/utils/logger";
 import { dummyPayment, PAYMENT_JOURNEY_URL } from "../mocks/payment.mock";
 import { mockConfirmationStatementSubmission } from "../mocks/confirmation.statement.submission.mock";
 import { getConfirmationStatement, updateConfirmationStatement } from "../../src/services/confirmation.statement.service";
+import * as sessionAcspUtils from "../../src/utils/session.acsp";
+import * as limitedPartnershipUtils from "../../src/utils/limited.partnership";
 
 const PropertiesMock = jest.requireMock('../../src/utils/properties');
 jest.mock('../../src/utils/properties', () => ({
@@ -398,5 +400,88 @@ describe("review controller tests", () => {
       expect(response.status).toEqual(302);
       expect(response.header.location).toBe(PAYMENT_JOURNEY_URL);
     });
+  });
+
+  describe("Back link test", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockGetConfirmationStatement.mockReset();
+      mockGetConfirmationStatement.mockResolvedValue(mockConfirmationStatementSubmission);
+      jest.spyOn(limitedPartnershipUtils, "isACSPJourney").mockReturnValue(true);
+    });
+
+    it("should redirect to Check SIC Code page when back button clicked, IS a Limited Partnership and NOT a private fund type", async() => {
+      const mockLimitedPartnership = {
+        companyNumber: COMPANY_NUMBER,
+        type: "limited-partnership-lp",
+        companyName: "Test Company"
+      };
+      mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);
+
+      const response = await request(app)
+        .get(URL);
+
+      const backPath = LP_SIC_CODE_SUMMARY_PATH
+        .replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER)
+        .replace(`:${urlParams.PARAM_TRANSACTION_ID}`, TRANSACTION_ID)
+        .replace(`:${urlParams.PARAM_SUBMISSION_ID}`, SUBMISSION_ID);
+
+      expect(response.text).toContain(backPath);
+    });
+
+    it("should redirect to Date page when back button clicked, IS a private fund Limited Partnership and NO date change", async() => {
+      jest.spyOn(sessionAcspUtils, "getAcspSessionData").mockReturnValue({
+        changeConfirmationStatementDate: false,
+        beforeYouFileCheck: true,
+        newConfirmationDate: null,
+        confirmAllInformationCheck: false,
+        confirmLawfulActionsCheck: false
+      });
+
+      const mockLimitedPartnership = {
+        companyNumber: COMPANY_NUMBER,
+        type: "limited-partnership-pflp",
+        companyName: "Test Company"
+      };
+      mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);
+
+      const response = await request(app)
+        .get(URL);
+
+      const backPath = LP_CS_DATE_PATH
+        .replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER)
+        .replace(`:${urlParams.PARAM_TRANSACTION_ID}`, TRANSACTION_ID)
+        .replace(`:${urlParams.PARAM_SUBMISSION_ID}`, SUBMISSION_ID);
+
+      expect(response.text).toContain(backPath);
+    });
+
+    it("should redirect to Check Your Answer page when back button clicked, IS a private fund Limited Partnership and HAS a date change", async() => {
+      jest.spyOn(sessionAcspUtils, "getAcspSessionData").mockReturnValue({
+        changeConfirmationStatementDate: true,
+        beforeYouFileCheck: true,
+        newConfirmationDate: null,
+        confirmAllInformationCheck: false,
+        confirmLawfulActionsCheck: false
+      });
+
+      const mockLimitedPartnership = {
+        companyNumber: COMPANY_NUMBER,
+        type: "limited-partnership-pflp",
+        companyName: "Test Company"
+      };
+      mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);
+
+      const response = await request(app)
+        .get(URL);
+
+      const backPath = LP_CHECK_YOUR_ANSWER_PATH
+        .replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER)
+        .replace(`:${urlParams.PARAM_TRANSACTION_ID}`, TRANSACTION_ID)
+        .replace(`:${urlParams.PARAM_SUBMISSION_ID}`, SUBMISSION_ID);
+
+      expect(response.text).toContain(backPath);
+    });
+
   });
 });


### PR DESCRIPTION
Back button from the ‘Submit Confirmation Statement’ screen navigates to one of four potential referring pages using session and company profile information to determine which.

**Screens to navigate back to:**
BODY -- No back button for this page in the no change journey.
ACSP & Non private fund -- 'Check SIC Codes'
ACSP & private fund & date changed -- 'Check Your Answers'
ACSP & private fund & no date changed -- 'Confirmation Statement Date'

**JIRA:** 
https://companieshouse.atlassian.net/browse/CSE-785

**ACSP & Non private fund video:** 

https://github.com/user-attachments/assets/75743f00-8dfe-4664-9854-b335e2fb23a1

**Both ACSP & private fund journeys:** 

https://github.com/user-attachments/assets/54a8d50d-51b0-4831-b511-00e08e0e33a0

