### PR TITLE
CSE-839: Put LP subtypes behind feature flags v2

### DIFF
--- a/src/utils/feature.flag.ts
+++ b/src/utils/feature.flag.ts
@@ -50,6 +50,6 @@ export const isPrivateFundLimitedPartnershipFeatureEnabled = (): boolean => {
   return isDateFeatureFlagEnabled("FEATURE_FLAG_PFLP_SUBTYPE_START_DATE", FEATURE_FLAG_PFLP_SUBTYPE_START_DATE, new Date());
 };
 
-export const isScottishPrivateFundimitedPartnershipFeatureEnabled = (): boolean => {
+export const isScottishPrivateFundLimitedPartnershipFeatureEnabled = (): boolean => {
   return isDateFeatureFlagEnabled("FEATURE_FLAG_SPFLP_SUBTYPE_START_DATE", FEATURE_FLAG_SPFLP_SUBTYPE_START_DATE, new Date());
 };

--- a/src/utils/limited.partnership.ts
+++ b/src/utils/limited.partnership.ts
@@ -5,7 +5,7 @@ import {
 } from "./constants";
 import { CONFIRMATION_PATH, LP_CHECK_YOUR_ANSWER_PATH, LP_CONFIRMATION_PATH, LP_CS_DATE_PATH, LP_REVIEW_PATH, LP_SIC_CODE_SUMMARY_PATH, REVIEW_PATH } from "../types/page.urls";
 import { Session } from "@companieshouse/node-session-handler";
-import { isLimitedPartnershipFeatureEnabled, isScottishLimitedPartnershipFeatureEnabled, isPrivateFundLimitedPartnershipFeatureEnabled, isScottishPrivateFundimitedPartnershipFeatureEnabled } from "./feature.flag";
+import { isLimitedPartnershipFeatureEnabled, isScottishLimitedPartnershipFeatureEnabled, isPrivateFundLimitedPartnershipFeatureEnabled, isScottishPrivateFundLimitedPartnershipFeatureEnabled } from "./feature.flag";
 import { getAcspSessionData } from "./session.acsp";
 
 export function isLimitedPartnershipCompanyType(companyProfile: CompanyProfile): boolean {
@@ -80,7 +80,7 @@ export function isLimitedPartnershipSubtypeFeatureFlagEnabled(companyProfile: Co
         case LIMITED_PARTNERSHIP_SUBTYPES.PFLP:
           return isPrivateFundLimitedPartnershipFeatureEnabled();
         case LIMITED_PARTNERSHIP_SUBTYPES.SPFLP:
-          return isScottishPrivateFundimitedPartnershipFeatureEnabled();
+          return isScottishPrivateFundLimitedPartnershipFeatureEnabled();
     }
   }
   return false;

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -20,13 +20,14 @@ import {
 } from "../../src/types/page.urls";
 import { getCompanyProfile, formatForDisplay } from "../../src/services/company.profile.service";
 import { validCompanyProfile, validLimitedPartnershipProfile } from "../mocks/company.profile.mock";
-import { isActiveFeature } from "../../src/utils/feature.flag";
+import { isActiveFeature, isScottishPrivateFundLimitedPartnershipFeatureEnabled } from "../../src/utils/feature.flag";
 import { toReadableFormat } from "../../src/utils/date";
 import { Settings as luxonSettings } from "luxon";
 import { urlUtils } from "../../src/utils/url";
 import { setCompanyTypeAndAcspNumberInSession } from "../mocks/session.mock";
 import { isLimitedPartnershipFeatureEnabled } from "../../src/utils/feature.flag";
-import { LIMITED_PARTNERSHIP_COMPANY_TYPE, LIMITED_PARTNERSHIP_SUBTYPES } from "../../src/utils/constants";
+import { LIMITED_PARTNERSHIP_COMPANY_TYPE } from "../../src/utils/constants";
+import { shouldRedirectToPaperFilingForInvalidLp } from "../../src/controllers/confirm.company.controller";
 
 const mockGetCompanyProfile = getCompanyProfile as jest.Mock;
 const mockFormatForDisplay = formatForDisplay as jest.Mock;
@@ -356,7 +357,7 @@ describe("Confirm company controller tests", () => {
 
   it("Should redirect to use paper stop screen if the LP feature flag is not enabled and type is LP subtype", async () => {
     mockGetCompanyProfile.mockResolvedValueOnce(validLimitedPartnershipProfile);
-    setCompanyTypeAndAcspNumberInSession(LIMITED_PARTNERSHIP_COMPANY_TYPE, "TSA001", LIMITED_PARTNERSHIP_SUBTYPES.LP);
+    setCompanyTypeAndAcspNumberInSession(LIMITED_PARTNERSHIP_COMPANY_TYPE, "TSA001", "abc");
     mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE);
     (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(false);
 
@@ -366,6 +367,57 @@ describe("Confirm company controller tests", () => {
     expect(response.status).toEqual(302);
     expect(mockCreateConfirmationStatement).not.toHaveBeenCalled();
     expect(response.header.location).toEqual(usePaperFilingPath);
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should false if the company type and subtype is LP", () => {
+    (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
+    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = "limited-partnership";
+
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are FLP and LP feature flag is not enabled", () => {
+    (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(false);
+    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = "limited-partnership";
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type is not LP and subtype is LP", () => {
+    (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
+    validLimitedPartnershipProfile.type = "otherType";
+    validLimitedPartnershipProfile.subtype = "limited-partnership";
+
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type and subtype is invalid", () => {
+    (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
+    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = "123";
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type is LP and subtype is SPFLP", () => {
+    (isScottishPrivateFundLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
+    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership";
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP, subtype is SPFLP and SPFLP feature flag is not enabled", () => {
+    (isScottishPrivateFundLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(false);
+    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership";
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
+  });
+
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP and subtype is not SPFLP", () => {
+    (isScottishPrivateFundLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
+    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership-test";
+    expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });
 
 });

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -369,7 +369,7 @@ describe("Confirm company controller tests", () => {
     expect(response.header.location).toEqual(usePaperFilingPath);
   });
 
-  it("shouldRedirectToPaperFilingForInvalidLp should false if the company type and subtype is LP", () => {
+  it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type and subtype are LP", () => {
     (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "limited-partnership";
@@ -377,10 +377,11 @@ describe("Confirm company controller tests", () => {
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
 
-  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are FLP and LP feature flag is not enabled", () => {
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are LP feature flag is not enabled", () => {
     (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(false);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "limited-partnership";
+
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });
 
@@ -392,10 +393,11 @@ describe("Confirm company controller tests", () => {
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
 
-  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type and subtype is invalid", () => {
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP and subtype is invalid", () => {
     (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "123";
+
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });
 
@@ -403,6 +405,7 @@ describe("Confirm company controller tests", () => {
     (isScottishPrivateFundLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership";
+
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
 
@@ -410,6 +413,7 @@ describe("Confirm company controller tests", () => {
     (isScottishPrivateFundLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(false);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership";
+
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });
 
@@ -417,6 +421,7 @@ describe("Confirm company controller tests", () => {
     (isScottishPrivateFundLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership-test";
+
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });
 

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -377,7 +377,7 @@ describe("Confirm company controller tests", () => {
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
 
-  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are LP feature flag is not enabled", () => {
+  it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are LP and feature flag is not enabled", () => {
     (isLimitedPartnershipFeatureEnabled as jest.Mock).mockReturnValue(false);
     validLimitedPartnershipProfile.type = "limited-partnership";
     validLimitedPartnershipProfile.subtype = "limited-partnership";

--- a/test/utils/feature.flag.unit.ts
+++ b/test/utils/feature.flag.unit.ts
@@ -5,7 +5,7 @@ import { ecctDayOneEnabled,
   isLimitedPartnershipFeatureEnabled,
   isScottishLimitedPartnershipFeatureEnabled,
   isPrivateFundLimitedPartnershipFeatureEnabled,
-  isScottishPrivateFundimitedPartnershipFeatureEnabled
+  isScottishPrivateFundLimitedPartnershipFeatureEnabled
 } from "../../src/utils/feature.flag";
 
 const PropertiesMock = jest.requireMock('../../src/utils/properties');
@@ -230,7 +230,7 @@ describe("feature flag tests", function() {
       };
       global.Date = MockDate as unknown as DateConstructor;
 
-      expect(isScottishPrivateFundimitedPartnershipFeatureEnabled()).toEqual(false);
+      expect(isScottishPrivateFundLimitedPartnershipFeatureEnabled()).toEqual(false);
 
       global.Date = OriginalDate;
 
@@ -238,17 +238,17 @@ describe("feature flag tests", function() {
 
     it("should return true if the date is the same as SPFLP feature flag start date", function() {
       PropertiesMock.FEATURE_FLAG_SPFLP_SUBTYPE_START_DATE = "2019-03-01";
-      expect(isScottishPrivateFundimitedPartnershipFeatureEnabled()).toEqual(true);
+      expect(isScottishPrivateFundLimitedPartnershipFeatureEnabled()).toEqual(true);
     });
 
     it("should return true if the date is past SPFLP feature flag start date", function() {
       PropertiesMock.FEATURE_FLAG_SPFLP_SUBTYPE_START_DATE = "2025-08-01";
-      expect(isScottishPrivateFundimitedPartnershipFeatureEnabled()).toEqual(true);
+      expect(isScottishPrivateFundLimitedPartnershipFeatureEnabled()).toEqual(true);
     });
 
     it("should return false if SPFLP feature flag start date is invalid", function() {
       PropertiesMock.FEATURE_FLAG_SPFLP_SUBTYPE_START_DATE = "2025-99-99";
-      expect(isScottishPrivateFundimitedPartnershipFeatureEnabled()).toEqual(false);
+      expect(isScottishPrivateFundLimitedPartnershipFeatureEnabled()).toEqual(false);
     });
   });
 


### PR DESCRIPTION
Ticket:
https://companieshouse.atlassian.net/browse/CSE-839

Changes:
- Since [ticket 838](https://companieshouse.atlassian.net/browse/CSE-838) created new subtype field, the logic need to be updated to satisfy the AC of [the ticket 839](https://companieshouse.atlassian.net/browse/CSE-839)
- Created the unit test for `shouldRedirectToPaperFilingForInvalidLp` function
- rename the function `isScottishPrivateFundimitedPartnershipFeatureEnabled` to `isScottishPrivateFundLimitedPartnershipFeatureEnabled`