### PR TITLE
CSE-649 : BYF conditional payment message

### DIFF
--- a/src/controllers/lp.before.you.file.controller.ts
+++ b/src/controllers/lp.before.you.file.controller.ts
@@ -85,8 +85,3 @@ function reloadPageWithError(req: Request, res: Response, lang: string, localInf
     }
   });
 }
-
-function next(e: any) {
-  throw new Error("Error retrieving Before You File page");
-}
-

--- a/src/controllers/lp.before.you.file.controller.ts
+++ b/src/controllers/lp.before.you.file.controller.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import { Templates } from "../types/template.paths";
 import { getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import * as urls from "../types/page.urls";
@@ -11,7 +11,7 @@ import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transact
 import { getTransaction } from "../services/transaction.service";
 import { isPaymentDue } from "../utils/payments";
 
-export const get = async (req: Request, res: Response) => {
+export const get = async (req: Request, res: Response, next: NextFunction) => {
 
   try {
     const session: Session = req.session as Session;
@@ -87,6 +87,6 @@ function reloadPageWithError(req: Request, res: Response, lang: string, localInf
 }
 
 function next(e: any) {
-  throw new Error("Function not implemented.");
+  throw new Error("Error retrieving Before You File page");
 }
 

--- a/src/controllers/lp.before.you.file.controller.ts
+++ b/src/controllers/lp.before.you.file.controller.ts
@@ -8,7 +8,8 @@ import { getAcspSessionData, resetAcspSession, updateAcspSessionData } from "../
 import { urlUtils } from "../utils/url";
 import { getCompanyProfileFromSession } from "../utils/session";
 import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transaction/types";
-import { getTransaction } from "services/transaction.service";
+import { getTransaction } from "../services/transaction.service";
+import { isPaymentDue } from "../utils/payments";
 
 export const get = async (req: Request, res: Response) => {
   const session: Session = req.session as Session;
@@ -20,7 +21,6 @@ export const get = async (req: Request, res: Response) => {
   const transactionId = urlUtils.getTransactionIdFromRequestParams(req);
   const submissionId = urlUtils.getSubmissionIdFromRequestParams(req);
   const transaction: Transaction = await getTransaction(session, transactionId);
-
 
 
   return res.render(Templates.LP_BEFORE_YOU_FILE, {

--- a/test/controllers/lp.before.you.file.unit.ts
+++ b/test/controllers/lp.before.you.file.unit.ts
@@ -36,19 +36,6 @@ describe("start before you file controller tests", () => {
     expect(response.text).toContain("Before you file a confirmation statement");
   });
 
-  it("should return payment text if payment is due", async () => {
-    (getCompanyProfile as jest.Mock).mockResolvedValue({
-      companyNumber: COMPANY_NUMBER,
-      type: LIMITED_PARTNERSHIP_COMPANY_TYPE,
-      subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
-      companyName: "Test Company"
-    });
-    const response = await request(app).get(URL);
-
-    expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-    expect(response.text).toContain("You can pay by debit or credit card. You cannot pay with a Companies House payment account.");
-  });
-
   it("should forward to Confirmation Statement Date page", async () => {
     const response = await request(app)
       .post(URL).set('Content-Type', 'application/json')

--- a/test/controllers/lp.before.you.file.unit.ts
+++ b/test/controllers/lp.before.you.file.unit.ts
@@ -5,7 +5,6 @@ import { LP_BEFORE_YOU_FILE_PATH, urlParams } from "../../src/types/page.urls";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
 import { LIMITED_PARTNERSHIP_COMPANY_TYPE, LIMITED_PARTNERSHIP_SUBTYPES } from "../../src/utils/constants";
 import { getTransaction } from "../../src/services/transaction.service";
-import { isPaymentDue } from "../../src/utils/payments";
 
 jest.mock("../../src/services/company.profile.service", () => ({
   getCompanyProfile: jest.fn()
@@ -27,7 +26,6 @@ const URL = LP_BEFORE_YOU_FILE_PATH
   .replace(`:${urlParams.PARAM_COMPANY_NUMBER}`, COMPANY_NUMBER)
   .replace(`:${urlParams.PARAM_TRANSACTION_ID}`, TRANSACTION_ID)
   .replace(`:${urlParams.PARAM_SUBMISSION_ID}`, SUBMISSION_ID);
-const mockIsPaymentDue = isPaymentDue as jest.Mock;
 
 
 describe("start before you file controller tests", () => {

--- a/test/controllers/lp.before.you.file.unit.ts
+++ b/test/controllers/lp.before.you.file.unit.ts
@@ -36,6 +36,19 @@ describe("start before you file controller tests", () => {
     expect(response.text).toContain("Before you file a confirmation statement");
   });
 
+  it("should return payment text if payment is due", async () => {
+    (getCompanyProfile as jest.Mock).mockResolvedValue({
+      companyNumber: COMPANY_NUMBER,
+      type: LIMITED_PARTNERSHIP_COMPANY_TYPE,
+      subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
+      companyName: "Test Company"
+    });
+    const response = await request(app).get(URL);
+
+    expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    expect(response.text).toContain("You can pay by debit or credit card. You cannot pay with a Companies House payment account.");
+  });
+
   it("should forward to Confirmation Statement Date page", async () => {
     const response = await request(app)
       .post(URL).set('Content-Type', 'application/json')

--- a/test/middleware/acsp.validation.middleware.unit.ts
+++ b/test/middleware/acsp.validation.middleware.unit.ts
@@ -54,7 +54,6 @@ middlewareMocks.mockSessionMiddleware.mockImplementation((req: Request, res: Res
 describe("start ACSP validation middleware tests", () => {
 
   beforeEach(() => {
-    jest.setTimeout(20000)
     jest.clearAllMocks();
   });
 
@@ -62,8 +61,8 @@ describe("start ACSP validation middleware tests", () => {
     setCompanyTypeAndAcspNumberInSession(LIMITED_PARTNERSHIP_COMPANY_TYPE, ACSP_NUMBER, LIMITED_PARTNERSHIP_SUBTYPES.LP);
 
     (getTransaction as jest.Mock).mockResolvedValue({
-            id: TRANSACTION_ID
-        });
+      id: TRANSACTION_ID
+    });
 
     const response = await request(app).get(URL_LP_BEFORE);
 

--- a/test/middleware/acsp.validation.middleware.unit.ts
+++ b/test/middleware/acsp.validation.middleware.unit.ts
@@ -6,6 +6,11 @@ import { LIMITED_PARTNERSHIP_COMPANY_TYPE, LIMITED_PARTNERSHIP_SUBTYPES } from "
 import middlewareMocks from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
+import { getTransaction } from "../../src/services/transaction.service";
+
+jest.mock("../../src/services/transaction.service", () => ({
+  getTransaction: jest.fn()
+}));
 
 const ACSP_NUMBER = "TSA001";
 const COMPANY_NUMBER = "12345678";
@@ -55,6 +60,11 @@ describe("start ACSP validation middleware tests", () => {
 
   it("acspValidationMiddleware should redirect to LP before you file page if user is ACSP member and LP type", async () => {
     setCompanyTypeAndAcspNumberInSession(LIMITED_PARTNERSHIP_COMPANY_TYPE, ACSP_NUMBER, LIMITED_PARTNERSHIP_SUBTYPES.LP);
+
+    (getTransaction as jest.Mock).mockResolvedValue({
+            id: TRANSACTION_ID
+        });
+
     const response = await request(app).get(URL_LP_BEFORE);
 
     expect(middlewareMocks.mockAcspValidationMiddleware).toHaveBeenCalled();

--- a/test/middleware/acsp.validation.middleware.unit.ts
+++ b/test/middleware/acsp.validation.middleware.unit.ts
@@ -49,6 +49,7 @@ middlewareMocks.mockSessionMiddleware.mockImplementation((req: Request, res: Res
 describe("start ACSP validation middleware tests", () => {
 
   beforeEach(() => {
+    jest.setTimeout(20000)
     jest.clearAllMocks();
   });
 

--- a/views/limited-partners/components/before-you-file/before-you-file.njk
+++ b/views/limited-partners/components/before-you-file/before-you-file.njk
@@ -27,7 +27,7 @@
 
                 <h1 class="govuk-heading-xl">
                     <span class="govuk-caption-l" style="text-transform: uppercase">
-                     {{company.companyName}} ({{company.companyNumber}})
+                        {{company.companyName}} ({{company.companyNumber}})
                     </span>
                     {{i18n.BYFPageTitle}}
                 </h1>
@@ -45,23 +45,24 @@
                         </a>
                     {% else %}
                         {{i18n.BYFFileUpdatesParagraphLink}}
-                    {% endif %}    
+                    {% endif %}
                     {{i18n.BYFFileUpdatesParagraphEnd}}
                 </p>
 
                 <p class="govuk-body">
                     {{i18n.BYFSubmittedUpdatesParagraph}}</p>
 
-
                 {% set checkboxError = null %}
                 {% if errors and pageProperties.isPost %}
-                    {% set checkboxError = { "text": i18n.BYFErrorMessageNotChecked } %}
+                    {% set checkboxError = {
+                        "text": i18n.BYFErrorMessageNotChecked
+                    } %}
                 {% endif %}
-                
+
                 <form  method="POST">
                     {% include "../../partials/csrf-token.njk" %}
 
-                        {{ govukCheckboxes({
+                    {{ govukCheckboxes({
                             name: "byfCheckbox",
                             fieldset: {},
                             hint: {},
@@ -76,20 +77,24 @@
                             ]
                         }) }}
 
-                    <p class="govuk-heading-l">
-                        {{i18n.BYFFeeInfoTitle}}</p>
+                    {% if isPaymentDue %}
 
-                    <p class="govuk-body">
-                        {{i18n.BYFFeeInfoParagraph1 | safe}}</p>
+                        <p class="govuk-heading-l">
+                            {{i18n.BYFFeeInfoTitle}}</p>
 
-                    <p class="govuk-body">
-                        {{i18n.BYFFeeInfoParagraph2}}</p>    
+                        <p class="govuk-body">
+                            {{i18n.BYFFeeInfoParagraph1 | safe}}</p>
+
+                        <p class="govuk-body">
+                            {{i18n.BYFFeeInfoParagraph2}}</p>
+
+                    {% endif %}
 
                     {{ govukButton({
                         id: 'continue',
                         text: i18n.BYFContinueBotton,
                         type: "submit"
-                    }) }}        
+                    }) }}
                 </form>
             </div>
         </div>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/CSE-649

Conditionally showing payment related text on before you file screen

Add **isPaymentDue** logic to **Before You File** controller and view

- Integrated isPaymentDue(transaction, submissionId) into the GET handler to conditionally render payment-related messaging.
- Updated Nunjucks template to display fee information when payment is due.
- Added unit tests to cover both true and false cases for isPaymentDue.
- Refactored controller to support error handling 

**When payment is due**
<img width="902" height="930" alt="image" src="https://github.com/user-attachments/assets/535526dc-c8db-4a5d-8cc5-17277a5d5170" />


**When payment is not due** 
<img width="1290" height="929" alt="image" src="https://github.com/user-attachments/assets/938dad7c-f148-446d-be66-97397ee72899" />
 