### PR TITLE
CSE-826-827: ACSP CS date on time and early screen

### DIFF
--- a/test/mocks/company.profile.mock.ts
+++ b/test/mocks/company.profile.mock.ts
@@ -57,7 +57,7 @@ export const validLimitedPartnershipProfile: CompanyProfile = {
   companyStatusDetail: "company status detail",
   confirmationStatement: {
     lastMadeUpTo: "2019-04-30",
-    nextDue: "2020-04-30",
+    nextDue: "2020-03-29",
     nextMadeUpTo: "2020-03-15",
     overdue: false,
   },

--- a/views/limited-partners/components/date/confirmation-statement-date.njk
+++ b/views/limited-partners/components/date/confirmation-statement-date.njk
@@ -71,35 +71,9 @@
                     {% if isTodayBeforeFileCsDate %}
                         <p class="govuk-body">{{i18n.CDSNotDueToFileEarly}}</p>
                         <p class="govuk-body">{{i18n.CDSExpectedFileDateTextEarly}} <b>{{cdsCurrentDate}}</b></p>
-                        <p class="govuk-body">{{i18n.CDSDateChangeExplainerStartEarly}} <b>{{dateOfToday}}</b>{{i18n.CDSDateChangeExplainerEndEarly}}</p>
+                        <p class="govuk-body">{{i18n.CDSDateChangeExplainerStartEarly}} <b>{{newCsDate}}</b>{{i18n.CDSDateChangeExplainerEndEarly}}</p>
                         <p class="govuk-body">{{i18n.CDSDateChangeExplainer2Early}}</p>
-
-                        {{ govukRadios({
-                            id: "confirmationStatementDate",
-                            name: "confirmationStatementDate",
-                            fieldset: {
-                                legend: {
-                                    text: i18n.CDSRadioButtonQuestion,
-                                    isPageHeading: true,
-                                    classes: "govuk-fieldset__legend--l"
-                                }
-                            },
-                            value: csDateRadioValue,
-                            items: [
-                                {
-                                    value: "no",
-                                    text: i18n.CDSRadioButtonNoTextEarly + dateOfToday
-                                },
-                                {
-                                    value: "yes",
-                                    text: i18n.CDSRadioButtonYes,
-                                    conditional: {
-                                        html: dateSelector
-                                    }
-                                }
-                            ],
-                            errorMessage: errorMessage
-                        })}}
+                        {% set noRadioButtonText = i18n.CDSRadioButtonNoTextEarly + dateOfToday %}
 
                     {% else %}
                         <p class="govuk-body">{{i18n.CDSCurrentDateText}} <b>{{cdsCurrentDate}}</b></p>
@@ -115,34 +89,36 @@
                                 <p class="govuk-body">{{i18n.CDSDateChangeExplainer}}</p>
                             </div>
                         </details>
+                        {% set noRadioButtonText = i18n.CDSRadioButtonNo %}
 
-                        {{ govukRadios({
-                            id: "confirmationStatementDate",
-                            name: "confirmationStatementDate",
-                            fieldset: {
-                                legend: {
-                                    text: i18n.CDSRadioButtonQuestion,
-                                    isPageHeading: true,
-                                    classes: "govuk-fieldset__legend--l"
+                    {% endif %}
+
+                    {{ govukRadios({
+                        id: "confirmationStatementDate",
+                        name: "confirmationStatementDate",
+                        fieldset: {
+                            legend: {
+                                text: i18n.CDSRadioButtonQuestion,
+                                isPageHeading: true,
+                                classes: "govuk-fieldset__legend--l"
+                            }
+                        },
+                        value: csDateRadioValue,
+                        items: [
+                            {
+                                value: "yes",
+                                text: i18n.CDSRadioButtonYes,
+                                conditional: {
+                                    html: dateSelector
                                 }
                             },
-                            value: csDateRadioValue,
-                            items: [
-                                {
-                                    value: "yes",
-                                    text: i18n.CDSRadioButtonYes,
-                                    conditional: {
-                                        html: dateSelector
-                                    }
-                                },
-                                {
-                                    value: "no",
-                                    text: i18n.CDSRadioButtonNo
-                                }
-                            ],
-                            errorMessage: errorMessage
-                        })}}
-                    {% endif %}  
+                            {
+                                value: "no",
+                                text: noRadioButtonText
+                            }
+                        ],
+                        errorMessage: errorMessage
+                    })}}
 
                     {{ govukButton({
                         text: i18n.CDSContinueButton


### PR DESCRIPTION
Ticket:
https://companieshouse.atlassian.net/browse/CSE-826
https://companieshouse.atlassian.net/browse/CSE-827

Changes:
- Get the CS date value from the source `next_made_up_to` field rather than `next_due`
- Show the due date value, which is from `next_due` field
- Keep the radio button order (Yes then No/No, I want ...) in on-time and early screen
- Display the new CS date from the date of today or the newConfirmationDate field of acsp session data
- Update unit test for the changes