### PR TITLE
CSE-895 - updated api-sdk-node version to 2.0.283 for optional CompayProfile.subtype

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/companieshouse/confirmation-statement-web#readme",
   "dependencies": {
-    "@companieshouse/api-sdk-node": "^2.0.280",
+    "@companieshouse/api-sdk-node": "^2.0.283",
     "@companieshouse/ch-node-utils": "^1.3.24",
     "@companieshouse/node-session-handler": "~5.1.4",
     "@companieshouse/structured-logging-node": "^2.0.1",


### PR DESCRIPTION
updated api-sdk-node version to 2.0.283 for optional CompayProfile.subtype