### PR TITLE
CSE-895 - updated package-lock.json for v2.0.283 of api-sdk-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@companieshouse/api-sdk-node": "^2.0.280",
+        "@companieshouse/api-sdk-node": "^2.0.283",
         "@companieshouse/ch-node-utils": "^1.3.24",
         "@companieshouse/node-session-handler": "~5.1.4",
         "@companieshouse/structured-logging-node": "^2.0.1",
@@ -585,9 +585,10 @@
       "dev": true
     },
     "node_modules/@companieshouse/api-sdk-node": {
-      "version": "2.0.280",
-      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.280.tgz",
-      "integrity": "sha512-tZytEagK0Q9jZEOGBdH6xMR/HWCqjvY7Qtz286I3FB14HBZNbzhAFcipp2f/vJlQCtQkhecUedVqTPKgLF7g5g==",
+      "version": "2.0.283",
+      "resolved": "https://registry.npmjs.org/@companieshouse/api-sdk-node/-/api-sdk-node-2.0.283.tgz",
+      "integrity": "sha512-kT/7cKLj2MkHWK18+kGjQUCKQ+De6rxn+gDJTg/RDgBKeNi8mSuf4pdvkDaMRR9cANKR2xusHryYys75oaVbhg==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.8.2",
         "camelcase-keys": "~6.2.2",


### PR DESCRIPTION
updated package-lock.json for v2.0.283 of api-sdk-node