### PR TITLE
CSE-1221 - ACSP - Refactor subtype definitions to short form

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -37,10 +37,10 @@ export const LP_CONFIRMATION_STATEMENT_ERROR: string = "Select if all required i
 export const LP_LAWFUL_ACTIVITY_STATEMENT_ERROR: string = "Select if intended future activities are lawful";
 export const ACCEPT_LAWFUL_PURPOSE_STATEMENT = "acceptLawfulPurposeStatement";
 export const LIMITED_PARTNERSHIP_COMPANY_TYPE = "limited-partnership";
-export const LIMITED_PARTNERSHIP_LP_SUBTYPE = "limited-partnership";
-export const LIMITED_PARTNERSHIP_SLP_SUBTYPE = "scottish-limited-partnership";
-export const LIMITED_PARTNERSHIP_PFLP_SUBTYPE = "private-fund-limited-partnership";
-export const LIMITED_PARTNERSHIP_SPFLP_SUBTYPE = "scottish-private-fund-limited-partnership";
+export const LIMITED_PARTNERSHIP_LP_SUBTYPE = "lp";
+export const LIMITED_PARTNERSHIP_SLP_SUBTYPE = "slp";
+export const LIMITED_PARTNERSHIP_PFLP_SUBTYPE = "pflp";
+export const LIMITED_PARTNERSHIP_SPFLP_SUBTYPE = "spflp";
 export const LIMITED_PARTNERSHIP_SUBTYPES = {
   LP: LIMITED_PARTNERSHIP_LP_SUBTYPE,
   SLP: LIMITED_PARTNERSHIP_SLP_SUBTYPE,

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -401,7 +401,7 @@ describe("Confirm company controller tests", () => {
   it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type and subtype are LP", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "limited-partnership";
-    validLimitedPartnershipProfile.subtype = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.LP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
@@ -409,7 +409,7 @@ describe("Confirm company controller tests", () => {
   it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are LP and feature flag is not enabled", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(false);
     validLimitedPartnershipProfile.type = "limited-partnership";
-    validLimitedPartnershipProfile.subtype = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.LP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });
@@ -417,7 +417,7 @@ describe("Confirm company controller tests", () => {
   it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type is not LP and subtype is LP", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "otherType";
-    validLimitedPartnershipProfile.subtype = "limited-partnership";
+    validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.LP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
@@ -433,7 +433,7 @@ describe("Confirm company controller tests", () => {
   it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type is LP and subtype is SPFLP", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
     validLimitedPartnershipProfile.type = "limited-partnership";
-    validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership";
+    validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.SPFLP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
   });
@@ -441,7 +441,7 @@ describe("Confirm company controller tests", () => {
   it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP, subtype is SPFLP and LP feature flag is not enabled", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(false);
     validLimitedPartnershipProfile.type = "limited-partnership";
-    validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership";
+    validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.SPFLP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
   });

--- a/test/controllers/confirm.company.controller.unit.ts
+++ b/test/controllers/confirm.company.controller.unit.ts
@@ -233,7 +233,7 @@ describe("Confirm company controller tests", () => {
 
   it("Should redirect to use paper stop screen when the eligibility status code is INVALID_COMPANY_TYPE_PAPER_FILING_ONLY, type limited-partnership", async () => {
     const originalType = validCompanyProfile.type;
-    validCompanyProfile.type  = "limited-partnership";
+    validCompanyProfile.type  = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
     mockIsActiveFeature.mockReturnValueOnce(true);
     mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.INVALID_COMPANY_TYPE_PAPER_FILING_ONLY);
@@ -356,7 +356,7 @@ describe("Confirm company controller tests", () => {
 
     // mockIsActiveFeature.mockReturnValueOnce(true);
     mockGetCompanyProfile.mockResolvedValueOnce(validLimitedPartnershipProfile);
-    setCompanyTypeAndAcspNumberInSession("limited-partnership", "ACSP-1234-5678");
+    setCompanyTypeAndAcspNumberInSession(LIMITED_PARTNERSHIP_COMPANY_TYPE, "ACSP-1234-5678");
     // mockCreateConfirmationStatement.mockResolvedValueOnce(201);
     mockEligibilityStatusCode.mockResolvedValueOnce(EligibilityStatusCode.COMPANY_VALID_FOR_SERVICE);
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
@@ -400,7 +400,7 @@ describe("Confirm company controller tests", () => {
 
   it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type and subtype are LP", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
-    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.LP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
@@ -408,7 +408,7 @@ describe("Confirm company controller tests", () => {
 
   it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type, subtype are LP and feature flag is not enabled", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(false);
-    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.LP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
@@ -424,7 +424,7 @@ describe("Confirm company controller tests", () => {
 
   it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP and subtype is invalid", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
-    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     validLimitedPartnershipProfile.subtype = "123";
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
@@ -432,7 +432,7 @@ describe("Confirm company controller tests", () => {
 
   it("shouldRedirectToPaperFilingForInvalidLp should return false if the company type is LP and subtype is SPFLP", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
-    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.SPFLP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeFalsy();
@@ -440,7 +440,7 @@ describe("Confirm company controller tests", () => {
 
   it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP, subtype is SPFLP and LP feature flag is not enabled", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(false);
-    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     validLimitedPartnershipProfile.subtype = LIMITED_PARTNERSHIP_SUBTYPES.SPFLP;
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
@@ -448,7 +448,7 @@ describe("Confirm company controller tests", () => {
 
   it("shouldRedirectToPaperFilingForInvalidLp should return true if the company type is LP and subtype is not SPFLP", () => {
     (isLimitedPartnershipFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
-    validLimitedPartnershipProfile.type = "limited-partnership";
+    validLimitedPartnershipProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
     validLimitedPartnershipProfile.subtype = "scottish-private-fund-limited-partnership-test";
 
     expect(shouldRedirectToPaperFilingForInvalidLp(validLimitedPartnershipProfile)).toBeTruthy();
@@ -497,7 +497,7 @@ describe("Confirm company controller tests", () => {
       newNextMadeUpToDate: today
     } as NextMadeUpToDate);
 
-    validCompanyProfile.type = "limited-partnership";
+    validCompanyProfile.type = LIMITED_PARTNERSHIP_COMPANY_TYPE;
 
     const response = await request(app)
       .get(CONFIRM_COMPANY_PATH);

--- a/test/controllers/review.controller.unit.ts
+++ b/test/controllers/review.controller.unit.ts
@@ -133,7 +133,7 @@ function setupLimitedPartnershipCompany() {
   const mockLimitedPartnership = {
     companyNumber: COMPANY_NUMBER,
     type: "limited-partnership",
-    subtype: "limited-partnership",
+    subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
     jurisdiction: "england-wales",
     companyName: "Test Company"
   };
@@ -146,7 +146,7 @@ function setupScottishLimitedPartnershipCompany() {
   const mockScottishLimitedPartnership = {
     companyNumber: COMPANY_NUMBER,
     type: "limited-partnership",
-    subtype: "scottish-limited-partnership",
+    subtype: LIMITED_PARTNERSHIP_SUBTYPES.SLP,
     jurisdiction: "scotland",
     companyName: "Test Company"
   };
@@ -462,7 +462,7 @@ describe("review controller tests", () => {
       const mockLimitedPartnership = {
         companyNumber: COMPANY_NUMBER,
         type: "limited-partnership",
-        subtype: "limited-partnership",
+        subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
         companyName: "Test Company"
       };
       mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);
@@ -482,7 +482,7 @@ describe("review controller tests", () => {
       const mockLimitedPartnership = {
         companyNumber: COMPANY_NUMBER,
         type: "limited-partnership",
-        subtype: "limited-partnership",
+        subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
         companyName: "Test Company"
       };
       mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);
@@ -522,7 +522,7 @@ describe("review controller tests", () => {
       const mockLimitedPartnership = {
         companyNumber: COMPANY_NUMBER,
         type: "limited-partnership",
-        subtype: "limited-partnership",
+        subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
         companyName: "Test Company"
       };
       mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);
@@ -542,7 +542,7 @@ describe("review controller tests", () => {
       const mockLimitedPartnership = {
         companyNumber: COMPANY_NUMBER,
         type: "limited-partnership",
-        subtype: "limited-partnership",
+        subtype: LIMITED_PARTNERSHIP_SUBTYPES.LP,
         companyName: "Test Company"
       };
       mockGetCompanyProfile.mockResolvedValueOnce(mockLimitedPartnership);

--- a/test/mocks/company.profile.mock.ts
+++ b/test/mocks/company.profile.mock.ts
@@ -80,7 +80,7 @@ export const validLimitedPartnershipProfile: CompanyProfile = {
   },
   sicCodes: ["123"],
   type: "limited-partnership",
-  subtype: "limited-partnership",
+  subtype: "lp",
 };
 
 export const validSDKResource: Resource<CompanyProfile> = {


### PR DESCRIPTION
Constants updated to use lp, slp, pflp, spflp
Test cases updated

Tested in local, able to access and use the LP journey with updated subtype values in Mongo DB. All unit tests passing.