### PR TITLE
Feature/cse 673 acsp cs date on time matomo analytics

### DIFF
--- a/src/controllers/lp.cs.date.controller.ts
+++ b/src/controllers/lp.cs.date.controller.ts
@@ -8,7 +8,7 @@ import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/compa
 import { getCompanyProfileFromSession } from "../utils/session";
 import { Session } from "@companieshouse/node-session-handler";
 import { AcspSessionData, getAcspSessionData } from "../utils/session.acsp";
-import { DMMMMYYYY_DATE_FORMAT, RADIO_BUTTON_VALUE, YYYYMMDD_WITH_HYPHEN_DATE_FORMAT } from "../utils/constants";
+import { DMMMMYYYY_DATE_FORMAT, RADIO_BUTTON_VALUE, YYYYMMDD_WITH_HYPHEN_DATE_FORMAT, MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME } from "../utils/constants";
 import { getReviewPath, isPflpLimitedPartnershipCompanyType, isSpflpLimitedPartnershipCompanyType, isACSPJourney, CsDateValue } from "../utils/limited.partnership";
 import { convertDateToString, formatDateString } from "../utils/date";
 import { isTodayBeforeFileCsDate, validateDateSelectorValue } from "../validators/lp.cs.date.validator";
@@ -57,7 +57,8 @@ export const get = (req: Request, res: Response) => {
     newCsDate: getNewCsDateForEarlyScreen(acspSessionData),
     csDateRadioValue,
     csDateValue,
-    errorMessage: null
+    errorMessage: null,
+    templateName: isTodayBeforeFileCsDate(company) ? MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_CS_DATE_EARLY : MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_CS_DATE_ON_TIME
   });
 };
 
@@ -158,7 +159,8 @@ function reloadPageWithError(options: ReloadPageOptions) {
     csDateValue,
     errorMessage: {
       text: errorMessage
-    }
+    },
+    templateName: isTodayBeforeFileCsDate(company) ? MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_CS_DATE_EARLY : MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_CS_DATE_ON_TIME
   });
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -61,6 +61,10 @@ export const YYYYMMDD_WITH_HYPHEN_DATE_FORMAT = "YYYY-MM-DD";
 export const DATE_DAY_REGEX: RegExp = /^(0?[1-9]|[12][0-9]|3[01])$/;
 export const DATE_MONTH_REGEX: RegExp = /^(0?[1-9]|1[0-2])$/;
 export const DATE_YEAR_REGEX: RegExp = /^\d{4}$/;
+export const MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME = {
+  LP_CS_DATE_ON_TIME: "confirmation-statement-date-dash-on-time",
+  LP_CS_DATE_EARLY: "confirmation-statement-date-dash-early"
+};
 
 export enum RADIO_BUTTON_VALUE {
   NO = "no",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -62,8 +62,8 @@ export const DATE_DAY_REGEX: RegExp = /^(0?[1-9]|[12][0-9]|3[01])$/;
 export const DATE_MONTH_REGEX: RegExp = /^(0?[1-9]|1[0-2])$/;
 export const DATE_YEAR_REGEX: RegExp = /^\d{4}$/;
 export const MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME = {
-  LP_CS_DATE_ON_TIME: "confirmation-statement-date-dash-on-time",
-  LP_CS_DATE_EARLY: "confirmation-statement-date-dash-early"
+  LP_CS_DATE_ON_TIME: "confirmation-statement-date-on-time",
+  LP_CS_DATE_EARLY: "confirmation-statement-date-early"
 };
 
 export enum RADIO_BUTTON_VALUE {

--- a/views/limited-partners/components/date/confirmation-statement-date.njk
+++ b/views/limited-partners/components/date/confirmation-statement-date.njk
@@ -93,21 +93,14 @@
 
                     {% if isTodayBeforeFileCsDate %}
                         <p class="govuk-body">{{i18n.CDSNotDueToFileEarly}}</p>
-                        <p class="govuk-body">{{i18n.CDSExpectedFileDateTextEarly}}
-                            <b>{{cdsCurrentDate}}</b>
-                        </p>
-                        <p class="govuk-body">{{i18n.CDSDateChangeExplainerStartEarly}}
-                            <b>{{newCsDate}}</b>{{i18n.CDSDateChangeExplainerEndEarly}}</p>
+                        <p class="govuk-body">{{i18n.CDSExpectedFileDateTextEarly}} <b>{{cdsCurrentDate}}</b></p>
+                        <p class="govuk-body">{{i18n.CDSDateChangeExplainerStartEarly}} <b>{{newCsDate}}</b>{{i18n.CDSDateChangeExplainerEndEarly}}</p>
                         <p class="govuk-body">{{i18n.CDSDateChangeExplainer2Early}}</p>
                         {% set noRadioButtonText = i18n.CDSRadioButtonNoTextEarly + dateOfToday %}
 
                     {% else %}
-                        <p class="govuk-body">{{i18n.CDSCurrentDateText}}
-                            <b>{{cdsCurrentDate}}</b>
-                        </p>
-                        <p class="govuk-body">{{i18n.CDSMustFileByDateText}}
-                            <b>{{cdsMustFileByDate}}</b>
-                        </p>
+                        <p class="govuk-body">{{i18n.CDSCurrentDateText}} <b>{{cdsCurrentDate}}</b></p>
+                        <p class="govuk-body">{{i18n.CDSMustFileByDateText}}<b>{{cdsMustFileByDate}}</b></p>
                         <details class="govuk-details" data-event-id="select-what-is-the-confirmation-statement-date-info">
                             <summary class="govuk-details__summary">
                                 <span class="govuk-details__summary-text">

--- a/views/limited-partners/components/date/confirmation-statement-date.njk
+++ b/views/limited-partners/components/date/confirmation-statement-date.njk
@@ -1,7 +1,7 @@
 {% extends "../../layouts/layout.njk" %}
-{% from "govuk/components/button/macro.njk"     import govukButton %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "govuk/components/radios/macro.njk"     import govukRadios %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set errors = pageProperties.errors %}
@@ -14,7 +14,7 @@
 
 {% set dateSelector -%}
 
-    {{ govukDateInput({
+{{ govukDateInput({
         id: "csDate",
         namePrefix: "csDate",
         fieldset: {
@@ -84,21 +84,31 @@
                             titleText: "There is a problem",
                             errorList: [
                                 { text: errorMessage.text, href: "#confirmationStatementDate" }
-                            ]
+                            ],
+                            attributes: {
+                                "data-event-id": "save-and-continue-button"
+                            }
                         }) }}
                     {% endif %}
 
                     {% if isTodayBeforeFileCsDate %}
                         <p class="govuk-body">{{i18n.CDSNotDueToFileEarly}}</p>
-                        <p class="govuk-body">{{i18n.CDSExpectedFileDateTextEarly}} <b>{{cdsCurrentDate}}</b></p>
-                        <p class="govuk-body">{{i18n.CDSDateChangeExplainerStartEarly}} <b>{{newCsDate}}</b>{{i18n.CDSDateChangeExplainerEndEarly}}</p>
+                        <p class="govuk-body">{{i18n.CDSExpectedFileDateTextEarly}}
+                            <b>{{cdsCurrentDate}}</b>
+                        </p>
+                        <p class="govuk-body">{{i18n.CDSDateChangeExplainerStartEarly}}
+                            <b>{{newCsDate}}</b>{{i18n.CDSDateChangeExplainerEndEarly}}</p>
                         <p class="govuk-body">{{i18n.CDSDateChangeExplainer2Early}}</p>
                         {% set noRadioButtonText = i18n.CDSRadioButtonNoTextEarly + dateOfToday %}
 
                     {% else %}
-                        <p class="govuk-body">{{i18n.CDSCurrentDateText}} <b>{{cdsCurrentDate}}</b></p>
-                        <p class="govuk-body">{{i18n.CDSMustFileByDateText}}<b>{{cdsMustFileByDate}}</b></p>
-                        <details class="govuk-details">
+                        <p class="govuk-body">{{i18n.CDSCurrentDateText}}
+                            <b>{{cdsCurrentDate}}</b>
+                        </p>
+                        <p class="govuk-body">{{i18n.CDSMustFileByDateText}}
+                            <b>{{cdsMustFileByDate}}</b>
+                        </p>
+                        <details class="govuk-details" data-event-id="select-what-is-the-confirmation-statement-date-info">
                             <summary class="govuk-details__summary">
                                 <span class="govuk-details__summary-text">
                                     {{i18n.CDSWhatIsDetailExpanderTitle}}
@@ -130,18 +140,27 @@
                                 text: i18n.CDSRadioButtonYes,
                                 conditional: {
                                     html: dateSelector
+                                },
+                                attributes: {
+                                    "data-event-id": "change-cs-date-yes"
                                 }
                             },
                             {
                                 value: "no",
-                                text: noRadioButtonText
+                                text: noRadioButtonText,
+                                attributes: {
+                                    "data-event-id": "change-cs-date-no"
+                                }
                             }
                         ],
                         errorMessage: errorMessage
                     })}}
 
                     {{ govukButton({
-                        text: i18n.CDSContinueButton
+                        text: i18n.CDSContinueButton,
+                        attributes: {
+                            "data-event-id": "save-and-continue-button"
+                        }
                     }) }}
                 </form>
             </div>

--- a/views/limited-partners/layouts/layout.njk
+++ b/views/limited-partners/layouts/layout.njk
@@ -20,4 +20,5 @@
 {% block bodyEnd %}
     {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
     {{super()}}
+    {% include "includes/piwik-scripts.html" %}
 {% endblock %}

--- a/views/limited-partners/partials/nav/back-link.njk
+++ b/views/limited-partners/partials/nav/back-link.njk
@@ -9,7 +9,10 @@
 {{ govukBackLink({
     href: backHref,
     text: i18n.HEADBackText,
-    classes: "govuk-!-margin-bottom-0 govuk-!-margin-top-0"
+    classes: "govuk-!-margin-bottom-0 govuk-!-margin-top-0",
+    attributes: {
+      "data-event-id": "back-link"
+    }
 }) }}
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">


### PR DESCRIPTION
Ticket:
https://companieshouse.atlassian.net/browse/CSE-673

Changes:
- Track the following event by Matomo for LP journey in CS date page
> Landing the page
> Show/hide the "what is the confirmation statement date" info box
> Click back button
> Yes/no radio button selection
> validation error