### PR TITLE
CSE-674: Implement Matomo data events into Check your Answer page

### DIFF
--- a/src/controllers/lp.check.your.answer.controller.ts
+++ b/src/controllers/lp.check.your.answer.controller.ts
@@ -41,7 +41,8 @@ export const get = (req: Request, res: Response) => {
     company,
     csDate: csDateString,
     csDatePageUrl,
-    nextPage
+    nextPage,
+    templateName: MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_CS_DATE_CYA
   });
 };
 

--- a/src/controllers/lp.check.your.answer.controller.ts
+++ b/src/controllers/lp.check.your.answer.controller.ts
@@ -9,7 +9,7 @@ import { urlUtils } from "../utils/url";
 import { Session } from "@companieshouse/node-session-handler";
 import moment from 'moment';
 import { getReviewPath, isPflpLimitedPartnershipCompanyType, isSpflpLimitedPartnershipCompanyType, isACSPJourney } from '../utils/limited.partnership';
-
+import { MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME } from "../utils/constants";
 
 export const get = (req: Request, res: Response) => {
   const lang = selectLang(req.query.lang);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -64,7 +64,8 @@ export const DATE_YEAR_REGEX: RegExp = /^\d{4}$/;
 export const MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME = {
   LP_CS_DATE_ON_TIME: "confirmation-statement-date-on-time",
   LP_CS_DATE_EARLY: "confirmation-statement-date-early",
-  LP_CS_BEFORE_YOU_FILE: "confirmation-statement-before-you-file"
+  LP_CS_BEFORE_YOU_FILE: "confirmation-statement-before-you-file",
+  LP_CS_DATE_CYA: "confirmation-statement-date-check-your-answer"
 };
 
 export enum RADIO_BUTTON_VALUE {

--- a/views/limited-partners/components/check-your-answer/lp-check-your-answer.njk
+++ b/views/limited-partners/components/check-your-answer/lp-check-your-answer.njk
@@ -31,7 +31,11 @@
                                             {
                                                 href: csDatePageUrl,
                                                 text: i18n.CDCYACheckAnswersChange,
-                                                visuallyHiddenText: i18n.CDCYACheckAnswersChange + " " + i18n.CDCYACheckAnswersStart
+                                                visuallyHiddenText: i18n.CDCYACheckAnswersChange + " " + i18n.CDCYACheckAnswersStart,              
+                                                attributes: {
+                                                        "data-event-id": "change-cs-date"
+                                                    }
+
                                             }    
                                     ]
                                 }
@@ -43,7 +47,10 @@
                     {{ govukButton({
                         text: i18n.CDCYAContinueButton,
                         type: "submit",
-                        id: "continue-button-id"
+                        id: "continue-button-id",
+                        attributes: {
+                                "data-event-id": "change-cs-date"
+                            }
                     })}}
 
                     </form>

--- a/views/limited-partners/components/check-your-answer/lp-check-your-answer.njk
+++ b/views/limited-partners/components/check-your-answer/lp-check-your-answer.njk
@@ -33,7 +33,7 @@
                                                 text: i18n.CDCYACheckAnswersChange,
                                                 visuallyHiddenText: i18n.CDCYACheckAnswersChange + " " + i18n.CDCYACheckAnswersStart,              
                                                 attributes: {
-                                                        "data-event-id": "change-cs-date"
+                                                        "data-event-id": "change-confirmation-statement-date-link"
                                                     }
 
                                             }    
@@ -49,7 +49,7 @@
                         type: "submit",
                         id: "continue-button-id",
                         attributes: {
-                                "data-event-id": "change-cs-date"
+                                "data-event-id": "continue-button-from-confirmation-statement-date-cya"
                             }
                     })}}
 


### PR DESCRIPTION
This pull request introduces enhancements to the Limited Partnership "Check Your Answer" flow, primarily to support improved analytics tracking and template management. The main changes involve adding a new Matomo page name constant, updating the controller to use it, and adding data attributes for event tracking in the Nunjucks template.

**Analytics and Template Improvements:**

* Added a new constant `LP_CS_DATE_CYA` to `MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME` in `constants.ts` to represent the "Check Your Answer" page for confirmation statement date.
* Updated the `get` controller in `lp.check.your.answer.controller.ts` to pass the new `templateName` to the view, enabling correct analytics tracking and template selection.

**Event Tracking Enhancements:**

* Modified the "Change" link for the confirmation statement date in `lp-check-your-answer.njk` to include a `data-event-id="change-cs-date"` attribute for analytics tracking.
* Updated the "Continue" button in the same template to also include a `data-event-id="change-cs-date"` attribute, supporting consistent event tracking.