### PR TITLE
CSE-676: Submit the Confirmation statement - Matomo Analytics

### DIFF
--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -18,7 +18,7 @@ import { isPaymentDue, executePaymentJourney } from "../utils/payments";
 import { handleLimitedPartnershipConfirmationJourney } from "../utils/confirmation/limited.partnership.confirmation";
 import { handleNoChangeConfirmationJourney } from "../utils/confirmation/no.change.confirmation";
 import { getAcspSessionData } from "../utils/session.acsp";
-import { CONFIRMATION_STATEMENT_SESSION_KEY, LAWFUL_ACTIVITY_STATEMENT_SESSION_KEY } from "../utils/constants";
+import { CONFIRMATION_STATEMENT_SESSION_KEY, LAWFUL_ACTIVITY_STATEMENT_SESSION_KEY, MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME } from "../utils/constants";
 import moment from "moment";
 import { CS01_COST } from "../utils/properties";
 
@@ -68,7 +68,8 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
         confirmationChecked: confirmationStatementCheck,
         lawfulActivityChecked: lawfulActivityStatementCheck,
         isLimitedPartnership: true,
-        csDateValue: formattedCsDate
+        csDateValue: formattedCsDate,
+        templateName: MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_SUBMIT_CONFIRMATION_STATEMENT
       });
 
     }
@@ -122,7 +123,8 @@ export const post = async (req: Request, res: Response, next: NextFunction) => {
           lawfulActivityChecked: lpJourneyResponse.renderData.lawfulActivityChecked,
           isLimitedPartnership: true,
           csDateValue: formattedCsDate,
-          isPaymentDue: isPaymentDue(transaction, submissionId)
+          isPaymentDue: isPaymentDue(transaction, submissionId),
+          templateName: MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_SUBMIT_CONFIRMATION_STATEMENT
         });
       }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -65,7 +65,8 @@ export const MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME = {
   LP_CS_DATE_ON_TIME: "confirmation-statement-date-on-time",
   LP_CS_DATE_EARLY: "confirmation-statement-date-early",
   LP_CS_BEFORE_YOU_FILE: "confirmation-statement-before-you-file",
-  LP_CS_DATE_CYA: "confirmation-statement-date-check-your-answer"
+  LP_CS_DATE_CYA: "confirmation-statement-date-check-your-answer",
+  LP_SUBMIT_CONFIRMATION_STATEMENT: "confirmation-statement-submit-confirmation-statement"
 };
 
 export enum RADIO_BUTTON_VALUE {

--- a/views/limited-partners/partials/lp-review.njk
+++ b/views/limited-partners/partials/lp-review.njk
@@ -1,11 +1,19 @@
 {% set checkboxHtml %}
 {{ i18n.SCSCheckboxActComplianceStart }}
 {% if company.jurisdiction == "scotland" %}
-  <a class="govuk-link" target="_blank" href="https://www.legislation.gov.uk/uksi/2017/694/regulation/35/">
+  <a class="govuk-link" 
+  target="_blank" 
+  href="https://www.legislation.gov.uk/uksi/2017/694/regulation/35/"
+  data-event-id="view-scottish-lp-legislation-link"
+>
     {{ i18n.SCSCheckboxActComplianceLinkScotland }}
   </a>
 {% else %}
-  <a class="govuk-link" target="_blank" href="https://www.legislation.gov.uk/ukpga/Edw7/7/24/section/10D">
+  <a class="govuk-link" 
+  target="_blank" 
+  href="https://www.legislation.gov.uk/ukpga/Edw7/7/24/section/10D"
+  data-event-id="view-lp-legislation-link"
+>
     {{ i18n.SCSCheckboxActComplianceLinkEWNI }}
   </a>
 {% endif %}
@@ -71,14 +79,20 @@
           {% if errorList | length > 0 %}
             {{ govukErrorSummary({
               titleText: i18n.SCSErrorTitle,
-              errorList: errorList
+              errorList: errorList,
+              attributes: {
+                  "data-event-id": "error-summary"
+                }
             }) }}
           {% endif %}
 
 
           {% if confirmationStatementError %}
             {% set confirmationStatementError = {
-              text: i18n.SCSConfirmationStatementError
+              text: i18n.SCSConfirmationStatementError,
+              attributes: {
+                  "data-event-id": "confirm-statement-error"
+                }
             } %}
           {% else %}
             {% set confirmationStatementError = false %}
@@ -86,7 +100,10 @@
 
           {% if lawfulActivityStatementError %}
             {% set lawfulActivityStatementError = {
-              text: i18n.SCSLawfulActivityStatementError
+              text: i18n.SCSLawfulActivityStatementError,
+              attributes: {
+                  "data-event-id": "lawful-activity-error"
+                }
             } %}
           {% else %}
             {% set lawfulActivityStatementError = false %}
@@ -113,7 +130,7 @@
                 checked: confirmationChecked,
                 value: "true",
                 attributes: {
-                  "data-event-id": "confirmation-statement-checkbox-clicked"
+                  "data-event-id": "confirm-required-information-checkbox"
                 }
               }
             ]
@@ -137,7 +154,7 @@
                 name: "confirmationStatement",
                 value: "true",
                 attributes: {
-                  "data-event-id": "confirmation-statement-checkbox-clicked"
+                  "data-event-id": "confirm-required-information-checkbox"
                 }
               }
             ]
@@ -164,7 +181,7 @@
                 checked: lawfulActivityChecked,
                 value: "true",
                 attributes: {
-                  "data-event-id": "lawful-activity-statement-checkbox-clicked"
+                  "data-event-id": "confirm-lawful-activity-checkbox"
                 }
               }
             ]
@@ -187,7 +204,7 @@
                 name: "lawfulActivityStatement",
                 value: "true",
                 attributes: {
-                  "data-event-id": "lawful-activity-statement-checkbox-clicked"
+                  "data-event-id": "confirm-lawful-activity-checkbox"
                 }
               }
             ]
@@ -207,7 +224,7 @@
           text: i18n.SCSContinueButtonPayment,
           attributes: {
             id: "confirm-and-pay",
-            "data-event-id": "confirm-and-pay-button",
+            "data-event-id": "submit-confirmation-statement-and-pay",
             "onclick": "_paq.push(['trackGoal', 4])"
           }
         }) }}
@@ -216,7 +233,7 @@
           text: i18n.SCSContinueButtonNoPayment,
           attributes: {
             id: "confirm-and-submit",
-            "data-event-id": "confirm-and-submit-button",
+            "data-event-id": "submit-confirmation-statement",
             "onclick": "_paq.push(['trackGoal', 5])"
           }
         }) }}


### PR DESCRIPTION
This pull request enhances analytics tracking and event tagging for the limited partnership review and submission journey. The main changes include introducing a new Matomo page name constant for the submit confirmation statement step, passing this value through the controller, and updating event IDs for better tracking in the review template. Additionally, data-event-id attributes have been added to error messages and key links for improved analytics.

**Analytics and event tracking improvements:**

* Added a new constant `LP_SUBMIT_CONFIRMATION_STATEMENT` to `MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME` in `constants.ts` for Matomo page tracking of the submit confirmation statement step.
* Updated the `review.controller.ts` to pass the new `templateName` property (`MATOMO_LIMITED_PARTNERSHIP_PAGE_NAME.LP_SUBMIT_CONFIRMATION_STATEMENT`) to the view in both GET and POST handlers. 

**Template and event ID enhancements:**

* In `lp-review.njk`, standardized and clarified `data-event-id` values for checkboxes, buttons, and links to improve event tracking granularity (e.g., changed checkbox event IDs to `confirm-required-information-checkbox` and `confirm-lawful-activity-checkbox`; updated button event IDs for submission actions). 
* Added `data-event-id` attributes to error summary and error messages for confirmation statement and lawful activity statement errors, enabling error tracking in analytics.
* Added `data-event-id` attributes to legislation links for Scotland and England/Wales/NI to track when users view legal references.