### PR TITLE
CSE-1273 Format CS01_COST to 2 Decimal places

### DIFF
--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -65,6 +65,6 @@ export const LOCALES_ENABLED = getEnvironmentVariable("LOCALES_ENABLED", "true")
 
 export const LOCALES_PATH = getEnvironmentVariable("LOCALES_PATH", "locales");
 
-export const CS01_COST = getEnvironmentVariable("CS01_COST");
+export const CS01_COST = Number(getEnvironmentVariable("CS01_COST")).toFixed(2);
 
 export const CS01_PAPER_FEE = getEnvironmentVariable("CS01_PAPER_FEE");


### PR DESCRIPTION
Update CS01_COST value to format to 2 decimal places ie. "00.00"

This will format the env var to what we need without altering any other functionality as the toFixed() method in TypeScript formats a number using fixed-point notation, returning a **string** with the specified number of digits after the decimal point.