### PR TITLE
fix (FS-337): Added missing back button on submit confirmation statement page

### DIFF
--- a/src/controllers/lp.before.you.file.controller.ts
+++ b/src/controllers/lp.before.you.file.controller.ts
@@ -38,7 +38,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
     let prevPageURL = `${urls.CONFIRM_COMPANY_PATH}?companyNumber=${urlUtils.getCompanyNumberFromRequestParams(req)}`;
     let gciReturnUrl = session?.getExtraData('gci_return_url') as string;
     if (gciReturnUrl) {
-        prevPageURL = gciReturnUrl;
+      prevPageURL = gciReturnUrl;
     }
 
     return res.render(Templates.LP_BEFORE_YOU_FILE, {

--- a/test/controllers/review.controller.unit.ts
+++ b/test/controllers/review.controller.unit.ts
@@ -11,7 +11,7 @@ import { Transaction } from "@companieshouse/api-sdk-node/dist/services/transact
 import request from "supertest";
 import mocks from "../mocks/all.middleware.mock";
 import app from "../../src/app";
-import { CONFIRMATION_PATH, LP_CHECK_YOUR_ANSWER_PATH, LP_CONFIRMATION_PATH, LP_CS_DATE_PATH, LP_REVIEW_PATH, LP_SIC_CODE_SUMMARY_PATH, REVIEW_PATH, urlParams } from '../../src/types/page.urls';
+import { CONFIRMATION_PATH, LP_CHECK_YOUR_ANSWER_PATH, LP_CONFIRMATION_PATH, LP_CS_DATE_PATH, LP_REVIEW_PATH, LP_SIC_CODE_SUMMARY_PATH, REVIEW_PATH, TASK_LIST_PATH, urlParams } from '../../src/types/page.urls';
 import { urlUtils } from "../../src/utils/url";
 import { validCompanyProfile } from "../mocks/company.profile.mock";
 import { getCompanyProfile } from "../../src/services/company.profile.service";
@@ -74,6 +74,7 @@ const URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(REVIEW_
 const LP_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(LP_REVIEW_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 const CONFIRMATION_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(CONFIRMATION_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 const LP_CONFIRMATION_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(LP_CONFIRMATION_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
+const BACK_LINK_URL = urlUtils.getUrlWithCompanyNumberTransactionIdAndSubmissionId(TASK_LIST_PATH, COMPANY_NUMBER, TRANSACTION_ID, SUBMISSION_ID);
 
 const dummyTransactionNoCosts = {
   id: TRANSACTION_ID
@@ -194,6 +195,19 @@ describe("review controller tests", () => {
       expect(response.text).toContain(PAGE_HEADING);
       expect(response.text).not.toContain(COSTS_TEXT);
       expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("should contain back button", async () => {
+      mockGetCompanyProfile.mockResolvedValueOnce(validCompanyProfile);
+      mockGetTransaction.mockResolvedValueOnce(dummyTransactionNoCosts);
+      const response = await request(app)
+        .get(URL);
+
+      expect(response.status).toBe(200);
+      expect(mockGetTransaction).toBeCalledTimes(1);
+      expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+      expect(response.text).toContain("govuk-back-link");
+      expect(response.text).toContain(BACK_LINK_URL);
     });
 
     it("should show review page with costs text", async () => {

--- a/views/review.html
+++ b/views/review.html
@@ -30,6 +30,12 @@
   {% endif %}
 {% endblock %}
 
+{% block backLink %}
+  {% if not isLimitedPartnership %}
+    {% include "includes/back-link.html" %}
+  {% endif %}
+{% endblock %}
+
 {% block beforeContent %}
   {% if isLimitedPartnership %}
     {# Custom LP content here #}


### PR DESCRIPTION
JIRA Ticket ID: [FS-337](https://companieshouse.atlassian.net/browse/FS-337)

## Context

During some regression testing the team noticed that the back button was missing from the "Submit the confirmation statement" page.

I did some investigation, and it seems that the back button was removed accidentally during some changes ([source](https://github.com/companieshouse/confirmation-statement-web/pull/833/changes#diff-3576b766bc9596e21d04bab26c071a5a0712590f55eae3b3f02017db05ad854bL10)) to the review screen for accommodating Limited Partnerships (LP) Confirmation Statement submission.
These changes use a custom header component (`limited-partners/partials/header.njk`) which includes the back link/button.

## Description

This PR adds the missing button back into the review page (excluding limited partnerships).
It also adds a test for the back button on the review page.

## Testing

I've tested this locally with a (test/fake) limited company.
To be comprehensive, we should also regression test the flow for Limited Partnerships, and other Company Types (I wasn't able to do this locally).
It may be overkill, but as a follow up, we could add/update an automation test in `taf-playwright-filing-maintain` (there is a [helper](https://github.com/companieshouse/taf-playwright-filing-maintain/blob/da83c20a1d2ff9a1d7ff8e36cda7141f564e6c89/tests/confirmation-statement-web/helper/helper.ts#L44) for this already).

## Screenshots

|Before|After|
|--|--|
|![Before - no back button](https://github.com/user-attachments/assets/22534b37-18e1-41d4-8d6f-146dbb30416d)|![After - with back button](https://github.com/user-attachments/assets/ca7bd8be-a20f-44fe-8ab0-2974eeeb36f7)|

## Demo

https://github.com/user-attachments/assets/9fdb346e-a672-4f42-990c-497de2706e60




[FS-337]: https://companieshouse.atlassian.net/browse/FS-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ