### PR TITLE
feat: enable back link of company lookup screen

### DIFF
--- a/src/types/page.urls.ts
+++ b/src/types/page.urls.ts
@@ -28,7 +28,7 @@ export const ACCOUNTS_SIGNOUT_PATH = `${ACCOUNT_URL}/signout`;
 export const CONFIRM_COMPANY = SEPARATOR + Templates.CONFIRM_COMPANY;
 export const CONFIRMATION_STATEMENT = "/confirmation-statement";
 export const COMPANY_NUMBER = "/company-number";
-export const COMPANY_LOOKUP = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber={companyNumber}";
+export const COMPANY_LOOKUP = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber={companyNumber}&backLink=/confirmation-statement/";
 export const CONFIRM_COMPANY_PATH = CONFIRMATION_STATEMENT + CONFIRM_COMPANY;
 export const CONFIRMATION_STATEMENT_BODY = ACTIVE_SUBMISSION_BASE + "body/";
 export const PEOPLE_WITH_SIGNIFICANT_CONTROL = CONFIRMATION_STATEMENT_BODY + Templates.PEOPLE_WITH_SIGNIFICANT_CONTROL;

--- a/test/controllers/company.number.controller.unit.ts
+++ b/test/controllers/company.number.controller.unit.ts
@@ -2,7 +2,7 @@ import mocks from "../mocks/all.middleware.mock";
 import request from "supertest";
 import app from "../../src/app";
 
-const EXPECTED_LOCATION = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber=%7BcompanyNumber%7D";
+const EXPECTED_LOCATION = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber=%7BcompanyNumber%7D&backLink=/confirmation-statement/";
 
 describe("company number controller tests", () => {
 

--- a/test/controllers/confirmation.controller.unit.ts
+++ b/test/controllers/confirmation.controller.unit.ts
@@ -84,7 +84,7 @@ describe("Confirmation controller tests", () => {
 
     const response = await request(app).get(LP_URL);
 
-    const DIFFERENT_LIMITED_PARTNERSHIP_LINK_URL = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber=%7BcompanyNumber%7D";
+    const DIFFERENT_LIMITED_PARTNERSHIP_LINK_URL = "/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber=%7BcompanyNumber%7D&amp;backLink=/confirmation-statement/";
     const LIMITED_PARTNERSHIP_OVERVIEW_LINK_URL = "/confirmation-statement/company/12345678/transaction/66454/submission/435435/acsp/confirmation?overview=true";
     const DIFFERENT_LIMITED_PARTNERSHIP_LINK_TEXT = "File for a different limited partnership";
     const LIMITED_PARTNERSHIP_OVERVIEW_LINK_TEXT = "Return to the overview screen for this limited partnership";


### PR DESCRIPTION
This pull request updates the company lookup URL to include a `backLink` parameter, ensuring that users can navigate back to the confirmation statement page more easily. The change is reflected both in the application code and in the related unit tests to maintain consistency.

URL updates for improved navigation:

* Updated the `COMPANY_LOOKUP` URL in `src/types/page.urls.ts` to append a `backLink` query parameter, allowing users to return to the confirmation statement page after completing the company lookup.

Test updates for consistency:

* Modified the expected redirect location in `test/controllers/company.number.controller.unit.ts` to match the new `COMPANY_LOOKUP` URL with the `backLink` parameter.
* Updated the expected URL in `test/controllers/confirmation.controller.unit.ts` to include the `backLink` parameter, ensuring tests reflect the new navigation behavior.

[fs-374](https://companieshouse.atlassian.net/browse/FS-374)