### PR TITLE
CSE-981: Skip CS Web start screen when LP type query parameter supplied

### DIFF
--- a/src/controllers/start.controller.ts
+++ b/src/controllers/start.controller.ts
@@ -4,12 +4,12 @@ import { Templates } from "../types/template.paths";
 import { getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
 import { COMPANY_NUMBER, CONFIRMATION_STATEMENT } from "../types/page.urls";
 
-const parseTypes = (param: unknown): string[] => {
-  if (!param) return [];
-  if (Array.isArray(param)) {
-    return param.map(String).flatMap(p => String(p).split(",")).map(p => p.trim().toLowerCase()).filter(Boolean);
+const parseTypes = (typeParam: unknown): string[] => {
+  if (!typeParam) return [];
+  if (Array.isArray(typeParam)) {
+    return typeParam.map(String).flatMap(p => String(p).split(",")).map(p => p.trim().toLowerCase()).filter(Boolean);
   }
-  return String(param).split(",").map(p => p.trim().toLowerCase()).filter(Boolean);
+  return String(typeParam).split(",").map(p => p.trim().toLowerCase()).filter(Boolean);
 };
 
 const shouldSkipStart = (req: Request): boolean => {

--- a/src/controllers/start.controller.ts
+++ b/src/controllers/start.controller.ts
@@ -1,11 +1,31 @@
 import { Request, Response } from "express";
-import { CHS_URL, CS01_COST, PIWIK_START_GOAL_ID, FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021, EWF_URL, FEATURE_FLAG_SERVICE_WITHDRAWN_02102025 } from "../utils/properties";
+import { CHS_URL, CS01_COST, PIWIK_START_GOAL_ID, FEATURE_FLAG_FIVE_OR_LESS_OFFICERS_JOURNEY_21102021, EWF_URL, FEATURE_FLAG_SERVICE_WITHDRAWN_02102025, SKIP_START_PAGE_COMPANY_TYPES } from "../utils/properties";
 import { Templates } from "../types/template.paths";
 import { getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
+import { COMPANY_NUMBER, CONFIRMATION_STATEMENT } from "../types/page.urls";
+
+const parseTypes = (param: unknown): string[] => {
+  if (!param) return [];
+  if (Array.isArray(param)) {
+    return param.map(String).flatMap(p => String(p).split(",")).map(p => p.trim().toLowerCase()).filter(Boolean);
+  }
+  return String(param).split(",").map(p => p.trim().toLowerCase()).filter(Boolean);
+};
+
+const shouldSkipStart = (req: Request): boolean => {
+  const configured = String(SKIP_START_PAGE_COMPANY_TYPES || "").split(",").map(s => s.trim().toLowerCase()).filter(Boolean);
+  if (!configured.length) return false;
+  const types = parseTypes(req.query.type);
+  return types.some(t => configured.includes(t));
+};
 
 export const get = (req: Request, res: Response) => {
   const lang = selectLang(req.query.lang);
   const locales = getLocalesService();
+
+  if (shouldSkipStart(req)) {
+      return res.redirect(CONFIRMATION_STATEMENT + COMPANY_NUMBER);
+    }
 
   return res.render(Templates.START, {
     ...getLocaleInfo(locales, lang),

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -68,3 +68,5 @@ export const LOCALES_PATH = getEnvironmentVariable("LOCALES_PATH", "locales");
 export const CS01_COST = getEnvironmentVariable("CS01_COST");
 
 export const CS01_PAPER_FEE = getEnvironmentVariable("CS01_PAPER_FEE");
+
+export const SKIP_START_PAGE_COMPANY_TYPES = getEnvironmentVariable("SKIP_START_PAGE_COMPANY_TYPES", "limited-partnership");

--- a/test/controllers/start.controller.unit.ts
+++ b/test/controllers/start.controller.unit.ts
@@ -28,4 +28,30 @@ describe("start controller tests", () => {
     expect(middlewareMocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
   });
 
+  it("should redirect to company-number when type contains limited-partnership", async () => {
+    const response = await request(app)
+      .get("/confirmation-statement?type=limited-partnership");
+
+    expect(response.status).toBe(302);
+    expect(response.header.location).toEqual("/confirmation-statement/company-number");
+    expect(middlewareMocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
+  });
+
+  it("should return start page when type does not contain limited-partnership", async () => {
+    const response = await request(app)
+      .get("/confirmation-statement?type=ltd");
+
+    expect(response.text).toContain(EXPECTED_TEXT);
+    expect(middlewareMocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
+  });
+
+  it("should redirect when type contains limited-partnership case-insensitive or comma-separated", async () => {
+    const response = await request(app)
+      .get("/confirmation-statement?type=Limited-Partnership,other");
+
+    expect(response.status).toBe(302);
+    expect(response.header.location).toEqual("/confirmation-statement/company-number");
+    expect(middlewareMocks.mockAuthenticationMiddleware).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/CSE-981

This pull request introduces logic to allow certain company types to bypass the start page and be redirected directly to the company number entry page. The company types to skip are configurable via an environment variable, and the logic is robust to case and comma-separated values (value currently includes "limited-partnership". Unit tests have been added to ensure correct behaviour.

**Start page skipping for specific company types:**

- Added a new environment variable `SKIP_START_PAGE_COMPANY_TYPES` (defaulting to `"limited-partnership"`) to configure which company types should skip the start page (`src/utils/properties.ts`).
- Implemented the `shouldSkipStart` function in `start.controller.ts` to check if the request's `type` query parameter matches any configured types (case-insensitive, supports comma-separated lists). If matched, users are redirected to the company number entry page (`/confirmation-statement/company-number`) (`src/controllers/start.controller.ts`).

**Testing:**

- Added unit tests to verify that requests with matching company types are redirected, and others are not. Tests cover case-insensitivity and comma-separated values (`test/controllers/start.controller.unit.ts`).