### PR TITLE
CSE-1298 : Reposition error summary above <h1> on all screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1729,6 +1730,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1856,6 +1858,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3604,6 +3607,7 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3736,6 +3740,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
       "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3928,6 +3933,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -4164,6 +4170,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4512,6 +4519,7 @@
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4765,6 +4773,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4959,6 +4968,7 @@
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5570,6 +5580,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6293,6 +6304,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6544,6 +6556,7 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
       "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -7085,6 +7098,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10333,6 +10347,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10431,6 +10446,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1730,7 +1729,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1858,7 +1856,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3607,7 +3604,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3740,7 +3736,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
       "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3933,7 +3928,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -4170,7 +4164,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4519,7 +4512,6 @@
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4773,7 +4765,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4968,7 +4959,6 @@
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5580,7 +5570,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6304,7 +6293,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6556,7 +6544,6 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
       "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -7098,7 +7085,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10347,7 +10333,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10446,7 +10431,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/views/limited-partners/components/before-you-file/before-you-file.njk
+++ b/views/limited-partners/components/before-you-file/before-you-file.njk
@@ -29,6 +29,18 @@
         <div class="govuk-width-container">
             <div class="govuk-grid-column-two-thirds">
 
+                {% if errors and pageProperties.isPost %}
+                  {{ govukErrorSummary({
+                        titleText: "There is a problem",
+                        errorList: [
+                            {
+                                text: i18n.BYFErrorMessageNotChecked,
+                                href: "#byfCheckbox"
+                            }
+                        ]
+                    }) }}
+                {% endif %}
+
                 <h1 class="govuk-heading-xl">
                     <span class="govuk-caption-l" style="text-transform: uppercase">
                         {{company.companyName}} ({{company.companyNumber}})
@@ -45,18 +57,6 @@
                     {{ govukWarningText({
                         text: i18n.BYFAlternateTextPFLP,
                         iconFallbackText: "Warning"
-                    }) }}
-                {% endif %}
-
-                {% if errors and pageProperties.isPost %}
-                  {{ govukErrorSummary({
-                        titleText: "There is a problem",
-                        errorList: [
-                            {
-                                text: i18n.BYFErrorMessageNotChecked,
-                                href: "#byfCheckbox"
-                            }
-                        ]
                     }) }}
                 {% endif %}
 

--- a/views/limited-partners/components/date/confirmation-statement-date.njk
+++ b/views/limited-partners/components/date/confirmation-statement-date.njk
@@ -74,10 +74,6 @@
             <div class="govuk-grid-column-two-thirds">
                 <form action="" method="post">
                     {% include "includes/csrf_token.html" %}
-                    <h1 class="govuk-heading-xl">
-                        <span class="govuk-caption-l">{{company.companyName}} ({{company.companyNumber}})</span>
-                        {{i18n.CDSTitle}}
-                    </h1>
 
                     {% if errorMessage %}
                         {{ govukErrorSummary({
@@ -90,6 +86,11 @@
                             }
                         }) }}
                     {% endif %}
+
+                    <h1 class="govuk-heading-xl">
+                        <span class="govuk-caption-l">{{company.companyName}} ({{company.companyNumber}})</span>
+                        {{i18n.CDSTitle}}
+                    </h1>
 
                     {% if isTodayBeforeFileCsDate %}
                         <p class="govuk-body">{{i18n.CDSNotDueToFileEarly}}</p>

--- a/views/limited-partners/partials/lp-review.njk
+++ b/views/limited-partners/partials/lp-review.njk
@@ -22,6 +22,59 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    {% if ecctEnabled %}
+      {% if confirmationStatementError or lawfulActivityStatementError %}
+
+        {% set errorList = [] %}
+
+        {% if confirmationStatementError %}
+          {% set errorList = errorList.concat([{
+              text: i18n.SCSConfirmationStatementError,
+              href: "#confirmation-statement"
+            }]) %}
+        {% endif %}
+
+        {% if lawfulActivityStatementError %}
+          {% set errorList = errorList.concat([{
+              text: i18n.SCSLawfulActivityStatementError,
+              href: "#lawful-activity-statement"
+            }]) %}
+        {% endif %}
+
+        {% if errorList | length > 0 %}
+          {{ govukErrorSummary({
+              titleText: i18n.SCSErrorTitle,
+              errorList: errorList,
+              attributes: {
+                  "data-event-id": "error-summary"
+                }
+            }) }}
+        {% endif %}
+
+        {% if confirmationStatementError %}
+          {% set confirmationStatementError = {
+              text: i18n.SCSConfirmationStatementError,
+              attributes: {
+                  "data-event-id": "confirm-statement-error"
+                }
+            } %}
+        {% else %}
+          {% set confirmationStatementError = false %}
+        {% endif %}
+
+        {% if lawfulActivityStatementError %}
+          {% set lawfulActivityStatementError = {
+              text: i18n.SCSLawfulActivityStatementError,
+              attributes: {
+                  "data-event-id": "lawful-activity-error"
+                }
+            } %}
+        {% else %}
+          {% set lawfulActivityStatementError = false %}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+
     <h1 class="govuk-heading-xl">{{i18n.SCSTitle}}</h1>
 
     {{ govukTable({
@@ -58,57 +111,6 @@
     <form action="" method="post">
       {% include "includes/csrf_token.html" %}
       {% if ecctEnabled %}
-        {% if confirmationStatementError or lawfulActivityStatementError %}
-
-          {% set errorList = [] %}
-
-          {% if confirmationStatementError %}
-            {% set errorList = errorList.concat([{
-              text: i18n.SCSConfirmationStatementError,
-              href: "#confirmation-statement"
-            }]) %}
-          {% endif %}
-
-          {% if lawfulActivityStatementError %}
-            {% set errorList = errorList.concat([{
-              text: i18n.SCSLawfulActivityStatementError,
-              href: "#lawful-activity-statement"
-            }]) %}
-          {% endif %}
-
-          {% if errorList | length > 0 %}
-            {{ govukErrorSummary({
-              titleText: i18n.SCSErrorTitle,
-              errorList: errorList,
-              attributes: {
-                  "data-event-id": "error-summary"
-                }
-            }) }}
-          {% endif %}
-
-
-          {% if confirmationStatementError %}
-            {% set confirmationStatementError = {
-              text: i18n.SCSConfirmationStatementError,
-              attributes: {
-                  "data-event-id": "confirm-statement-error"
-                }
-            } %}
-          {% else %}
-            {% set confirmationStatementError = false %}
-          {% endif %}
-
-          {% if lawfulActivityStatementError %}
-            {% set lawfulActivityStatementError = {
-              text: i18n.SCSLawfulActivityStatementError,
-              attributes: {
-                  "data-event-id": "lawful-activity-error"
-                }
-            } %}
-          {% else %}
-            {% set lawfulActivityStatementError = false %}
-          {% endif %}
-        {% endif %}
 
         {% if confirmationChecked %}
 


### PR DESCRIPTION
This pull request primarily reorganizes the markup structure in several Nunjucks templates to ensure that error messages are displayed before page headings and main content, and that forms and tables are rendered in the correct order. The changes improve accessibility and user experience by ensuring that users see error summaries at the top of the page and that content is presented in a logical sequence.

Markup and content reordering for accessibility and clarity:

* Moved the error summary block above the page heading in `before-you-file.njk` so that users see error messages before the main content. [[1]](diffhunk://#diff-a5f0f9916326865aa269920903c444daab376775cefdcf8722ce2ffdfc9e494dR32-R43) [[2]](diffhunk://#diff-a5f0f9916326865aa269920903c444daab376775cefdcf8722ce2ffdfc9e494dL51-L62)
* Adjusted the order of the heading in `confirmation-statement-date.njk` to appear after any error summary, ensuring errors are visible first. [[1]](diffhunk://#diff-17c995b8b9168b0d168a5e6e708ff478b4684dcad4c42bf76fc42ff6595a3708L77-L80) [[2]](diffhunk://#diff-17c995b8b9168b0d168a5e6e708ff478b4684dcad4c42bf76fc42ff6595a3708R90-R94)
* In `lp-review.njk`, moved the heading and company details table to appear after the error handling logic and form setup, so that errors and form logic are processed before rendering the main content. [[1]](diffhunk://#diff-6cd320e0cce0b3aaaebe7da91b96701d389b3e876335428d3c6a455962edf700L25-L59) [[2]](diffhunk://#diff-6cd320e0cce0b3aaaebe7da91b96701d389b3e876335428d3c6a455962edf700R76-R113)
* Cleaned up extra blank lines and ensured consistent structure in `lp-review.njk`