### PR TITLE
CSE-1335 - To allow integrated entry for limited partnership from GCI,  have URL which does not do CSRF check

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -102,9 +102,9 @@ const csrfProtectionMiddleware = CsrfProtectionMiddleware({
     enabled: true,
     sessionCookieName: COOKIE_NAME,
 });
-app.use(urls.middlewarePaths, csrfProtectionMiddleware);
+app.use(urls.csrfCheckMiddlewarePaths, csrfProtectionMiddleware);
 
-app.post(`*/confirmation-statement/confirm-company`, validateIntegratedJourney);
+app.post(`*/confirmation-statement/integrated-entry`, validateIntegratedJourney);
 
 app.use(commonTemplateVariablesMiddleware);
 // apply our default router to /confirmation-statement

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -190,7 +190,10 @@ if (isServiceWithdrawnFeatureEnabled()) {
     router.get(urls.LP_CONFIRMATION, confirmationRoute.get);
 
     router.get(urls.LP_STOP_SCREEN, lpStopScreenRoute.get);
+
     router.get(urls.LP_TRANSITIONAL_STOP, lpTransitionalStopRoute.get);
 
     router.get(urls.LP_MUST_BE_AUTHORISED_AGENT, lpMustBeAuthorisedAgent.get);
+
+    router.post(urls.LP_INTEGRATED_ENTRY, confirmCompanyRoute.post);
 }

--- a/src/types/page.urls.ts
+++ b/src/types/page.urls.ts
@@ -138,5 +138,7 @@ export const LP_STOP_SCREEN = "/lp-stop-screen";
 export const LP_STOP_SCREEN_PATH = CONFIRMATION_STATEMENT + LP_STOP_SCREEN;
 export const LP_TRANSITIONAL_STOP = "/lp-transitional-stop";
 export const LP_TRANSITIONAL_STOP_PATH = CONFIRMATION_STATEMENT + LP_TRANSITIONAL_STOP;
+export const LP_INTEGRATED_ENTRY = "/integrated-entry";
 
 export const middlewarePaths = /\/confirmation-statement\/((?!healthcheck).)*/;
+export const csrfCheckMiddlewarePaths = /\/confirmation-statement\/((?!healthcheck|integrated-entry).*)/;


### PR DESCRIPTION
To allow integrated entry for limited partnership from GCI,  have an `integrated-entry` URL which does not do CSRF check