### PR TITLE
CSE-962: Empty associated SIC code list

### DIFF
--- a/src/controllers/lp.sic.code.summary.controller.ts
+++ b/src/controllers/lp.sic.code.summary.controller.ts
@@ -37,7 +37,13 @@ export const get = (req: Request, res: Response) => {
 
     const sicCodeSummaryList = getSicCodeSummaryList(req, lang, sicCodesList);
 
-    return renderPage(req, res, sicCodeSummaryList, sicCodesList, errors);
+    const removedLastSicCode =
+        sessionSicCodes !== undefined &&
+        Array.isArray(sessionSicCodes) &&
+        (sessionSicCodes as string[]).length === 0 &&
+        (company?.sicCodes?.length ?? 0) > 0;
+
+    return renderPage(req, res, sicCodeSummaryList, sicCodesList, errors, removedLastSicCode);
 };
 
 export const saveAndContinue = async (req: Request, res: Response) => {


### PR DESCRIPTION
Addressing bug raised 
This pull request updates the controller logic in `lp.sic.code.summary.controller.ts` to enhance how the page is rendered when the last SIC code is removed from the session. The main change is the introduction of a new flag, `removedLastSicCode`, which is passed to the `renderPage` function to indicate this specific scenario.

Enhancement to render logic:

* Added logic to detect when the last SIC code has been removed from the session and pass a `removedLastSicCode` flag to the `renderPage` function in `get` to handle this case.