### PR TITLE
CSE-1362 - Hold CS Date in ACSP Extra Data as a String so that the session won't cause GCI to fail when navigating back

### DIFF
--- a/src/controllers/lp.cs.date.controller.ts
+++ b/src/controllers/lp.cs.date.controller.ts
@@ -54,10 +54,12 @@ export const get = (req: Request, res: Response) => {
         if (acspSessionData.changeConfirmationStatementDate) {
             csDateRadioValue = RADIO_BUTTON_VALUE.YES;
             if (acspSessionData.newConfirmationDate) {
+                const newConfDateAsDate: Date = moment(acspSessionData.newConfirmationDate).toDate();
+
                 csDateValue = {
-                    csDateYear: `${acspSessionData.newConfirmationDate.getFullYear()}`,
-                    csDateMonth: `${acspSessionData.newConfirmationDate.getMonth() + 1}`,
-                    csDateDay: `${acspSessionData.newConfirmationDate.getDate()}`,
+                    csDateYear: `${newConfDateAsDate.getFullYear()}`,
+                    csDateMonth: `${newConfDateAsDate.getMonth() + 1}`,
+                    csDateDay: `${newConfDateAsDate.getDate()}`,
                 };
             }
         } else {
@@ -255,7 +257,7 @@ function saveCsDateIntoSession(
 ) {
     if (acspSessionData) {
         acspSessionData.changeConfirmationStatementDate = isChangedConfirmationStatementDate;
-        acspSessionData.newConfirmationDate = csDateInput;
+        acspSessionData.newConfirmationDate = moment(csDateInput).format(YYYYMMDD_WITH_HYPHEN_DATE_FORMAT);
     }
 }
 

--- a/src/controllers/lp.sic.code.summary.controller.ts
+++ b/src/controllers/lp.sic.code.summary.controller.ts
@@ -97,7 +97,7 @@ export const saveAndContinue = async (req: Request, res: Response) => {
 
     req.session?.setExtraData(SIC_CODE_SESSION_KEY, unsavedCodeList);
 
-    const submitDate = getDateSubmission(sessionData?.newConfirmationDate, req);
+    const submitDate = getDateSubmission(sessionData, req);
 
     await sendLimitedPartnershipTransactionUpdate(req, submitDate, sicCodeList);
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -5,6 +5,7 @@ import { DMMMMYYYY_DATE_FORMAT, YYYYMMDD_WITH_HYPHEN_DATE_FORMAT } from "./const
 import { Request } from "express";
 import { isTodayBeforeFileCsDate } from "../validators/lp.cs.date.validator";
 import { getCompanyProfileFromSession } from "./session";
+import { AcspSessionData } from "../utils/session.acsp";
 
 export const toReadableFormat = (dateToConvert: string): string => {
     if (!dateToConvert) {
@@ -83,9 +84,9 @@ function isDefined<T>(value: T | null | undefined): value is T {
     return value !== null && value !== undefined;
 }
 
-export function getDateSubmission(newConfirmationDate: Date | null | undefined, req: Request): any {
-    if (newConfirmationDate) {
-        return moment(newConfirmationDate).format(YYYYMMDD_WITH_HYPHEN_DATE_FORMAT);
+export function getDateSubmission(acspSessionData: AcspSessionData | null | undefined, req: Request): any {
+    if (acspSessionData?.newConfirmationDate) {
+        return moment(acspSessionData?.newConfirmationDate).format(YYYYMMDD_WITH_HYPHEN_DATE_FORMAT);
     }
 
     const date = isTodayBeforeFileCsDate(getCompanyProfileFromSession(req)) ? moment().startOf("day").toDate() : null;

--- a/src/utils/session.acsp.ts
+++ b/src/utils/session.acsp.ts
@@ -2,11 +2,12 @@ import { Session } from "@companieshouse/node-session-handler";
 import { ACSP_SESSION_KEY } from "../utils/constants";
 import { CondensedSicCodeData } from "@companieshouse/api-sdk-node/dist/services/sic-code";
 import { CsDateValue } from "./limited.partnership";
+import moment from "moment";
 
 export interface AcspSessionData {
     beforeYouFileCheck: boolean;
     changeConfirmationStatementDate: boolean | null;
-    newConfirmationDate: Date | null;
+    newConfirmationDate: string | null;
     confirmAllInformationCheck: boolean;
     confirmLawfulActionsCheck: boolean;
     companySubtype?: string;
@@ -41,10 +42,11 @@ export function updateAcspSessionData(session: Session, updates: Partial<AcspSes
 
 export function getCsDateValueFromSession(acspSessionData: AcspSessionData): CsDateValue | undefined {
     if (acspSessionData?.newConfirmationDate) {
+        const newConfDateAsDate: Date = moment(acspSessionData?.newConfirmationDate).toDate();
         return {
-            csDateYear: `${acspSessionData.newConfirmationDate.getFullYear()}`,
-            csDateMonth: `${acspSessionData.newConfirmationDate.getMonth() + 1}`,
-            csDateDay: `${acspSessionData.newConfirmationDate.getDate()}`,
+            csDateYear: `${newConfDateAsDate.getFullYear()}`,
+            csDateMonth: `${newConfDateAsDate.getMonth() + 1}`,
+            csDateDay: `${newConfDateAsDate.getDate()}`,
         };
     }
 }

--- a/test/controllers/lp.check.your.answer.unit.ts
+++ b/test/controllers/lp.check.your.answer.unit.ts
@@ -16,7 +16,7 @@ const URL = LP_CHECK_YOUR_ANSWER_PATH.replace(`:${urlParams.PARAM_COMPANY_NUMBER
     .replace(`:${urlParams.PARAM_SUBMISSION_ID}`, SUBMISSION_ID);
 const csDatePageUrl =
     "/confirmation-statement/company/12345678/transaction/66454/submission/435435/acsp/confirmation-statement-date?lang=en";
-const csDate = new Date("2025-08-01:00:00Z");
+const csDate = "2025-08-01";
 const acspSessionData = createDefaultAcspSessionData();
 
 jest.mock("../../src/utils/confirmation/limited.partnership.confirmation");

--- a/test/utils/date.unit.ts
+++ b/test/utils/date.unit.ts
@@ -204,13 +204,13 @@ describe("Date tests", () => {
             jest.clearAllMocks();
         });
 
-        it("should format and return newConfirmationDate when provided", () => {
-            const date = new Date("2023-10-01");
-            const result = getDateSubmission(date, mockReq);
-            expect(result).toBe(moment(date).format(YYYYMMDD_WITH_HYPHEN_DATE_FORMAT));
+        it("should format and return newConfirmationDate on ACSP Session Data when provided", () => {
+            const ascpSessionData: AcspSessionData = { newConfirmationDate: "2023-10-01" };
+            const result = getDateSubmission(ascpSessionData, mockReq);
+            expect(result).toBe(moment("2023-10-01").format(YYYYMMDD_WITH_HYPHEN_DATE_FORMAT));
         });
 
-        it("should return formatted current date when newConfirmationDate is null and today is before file CS date", () => {
+        it("should return formatted current date when no newConfirmationDate on ACSP Session Data and today is before file CS date", () => {
             (isTodayBeforeFileCsDate as jest.Mock).mockReturnValue(true);
             const todayStart = moment().startOf("day").toDate();
             jest.spyOn(dateUtils, "convertDateToString").mockReturnValue("2023-10-01");
@@ -222,7 +222,7 @@ describe("Date tests", () => {
             expect(result).toBe("2023-10-01");
         });
 
-        it("should return null formatted when newConfirmationDate is null and today is not before file CS date", () => {
+        it("should return null formatted when no newConfirmationDate on ACSP Session Data  and today is not before file CS date", () => {
             (isTodayBeforeFileCsDate as jest.Mock).mockReturnValue(false);
             jest.spyOn(dateUtils, "convertDateToString").mockReturnValue(null);
 


### PR DESCRIPTION
[CSE-1362](https://companieshouse.atlassian.net/browse/CSE-1362) 

Hold CS Date in ACSP Extra Data as a String so that the session won't cause GCI to fail when navigating back

[CSE-1362]: https://companieshouse.atlassian.net/browse/CSE-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ