### PR TITLE
CSE-1329: ACSP - Customise must-be-authorised-agent stop screen

### DIFF
--- a/locales/cy/must-be-authorised-agent.json
+++ b/locales/cy/must-be-authorised-agent.json
@@ -1,6 +1,16 @@
 {
-    "needToBeAddedToAuthorisedAgentAccountHeading": "Mae angen i chi gael eich ychwanegu at gyfrif asiant awdurdodedig i weld y dudalen hon",
-    "needToAskToBeAdded": "Bydd angen i chi ofyn am gael eich ychwanegu at gyfrif asiant awdurdodedig i weld ei ddefnyddwyr.",
-    "applyAsAnAuthorisedAgent": "Os nad oes cyfrif presennol ar gyfer eich busnes, gallwch ",
-    "applyAsAnAuthorisedAgentLink": "wneud cais i gofrestru fel asiant awdurdodedig gyda Thŷ'r Cwmnïau"
+  "needToBeAnAcspHeading": "CY-You must be an Authorised Corporate Service Provider (ACSP) to use this service",
+  "acspNotLinkedToEmail": "CY-You cannot use this service because the email you have signed in with is not linked to an ACSP account.",
+  "onlyAcspsCanFile": "CY-Only ACSPs can file for limited partnerships.",
+  "acspDefinition": "CY-An ACSP is an agent, such as an accountant or solicitor, that has registered with Companies House to file on behalf of clients. To register as an ACSP, the agent must be supervised for Anti-Money Laundering (AML) purposes.",
+  "workForRegisteredAcspHeading": "CY-If you work for a business that is registered as an ACSP",
+  "askBusinessToAddYou": "CY-You'll need to ask someone from your business to add you to its ACSP account.",
+  "findOutMoreReadSection": "CY-To find out more, read the section on how to use your account in our",
+  "guidanceBeingAnAcspLinkText": "CY-guidance on being an ACSP",
+  "needToRegisterAsAcspHeading": "CY-If you need to register as an ACSP",
+  "guidanceRegisteringAsAcspLinkText": "CY-Read the guidance on registering as an ACSP.",
+  "someoneElseInvolvedHeading": "CY-If you're someone else involved with the limited partnership",
+  "needToFindAnAcsp": "CY-You need to",
+  "findAnAcspLinkText": "CY-find an ACSP",
+  "toFileOnYourBehalf": "CY-to file on your behalf."
 }

--- a/locales/en/must-be-authorised-agent.json
+++ b/locales/en/must-be-authorised-agent.json
@@ -1,6 +1,16 @@
 {
-    "needToBeAddedToAuthorisedAgentAccountHeading": "You need to be added to an authorised agent account to view this page",
-    "needToAskToBeAdded": "You'll need to ask to be added to an authorised agent account to view its users.",
-    "applyAsAnAuthorisedAgent": "If there's not an existing account for your business, you can ",
-    "applyAsAnAuthorisedAgentLink": "apply to register as an authorised agent with Companies House"
+  "needToBeAnAcspHeading": "You must be an Authorised Corporate Service Provider (ACSP) to use this service",
+  "acspNotLinkedToEmail": "You cannot use this service because the email you have signed in with is not linked to an ACSP account.",
+  "onlyAcspsCanFile": "Only ACSPs can file for limited partnerships.",
+  "acspDefinition": "An ACSP is an agent, such as an accountant or solicitor, that has registered with Companies House to file on behalf of clients. To register as an ACSP, the agent must be supervised for Anti-Money Laundering (AML) purposes.",
+  "workForRegisteredAcspHeading": "If you work for a business that is registered as an ACSP",
+  "askBusinessToAddYou": "You'll need to ask someone from your business to add you to its ACSP account.",
+  "findOutMoreReadSection": "To find out more, read the section on how to use your account in our",
+  "guidanceBeingAnAcspLinkText": "guidance on being an ACSP",
+  "needToRegisterAsAcspHeading": "If you need to register as an ACSP",
+  "guidanceRegisteringAsAcspLinkText": "Read the guidance on registering as an ACSP.",
+  "someoneElseInvolvedHeading": "If you're someone else involved with the limited partnership",
+  "needToFindAnAcsp": "You need to",
+  "findAnAcspLinkText": "find an ACSP",
+  "toFileOnYourBehalf": "to file on your behalf."
 }

--- a/views/limited-partners/components/must-be-authorised-agent/must-be-authorised-agent.njk
+++ b/views/limited-partners/components/must-be-authorised-agent/must-be-authorised-agent.njk
@@ -1,10 +1,53 @@
 {% extends "../../layouts/layout.njk" %}
 {% set title = i18n.needToBeAddedToAuthorisedAgentAccountHeading %}
 {% block content %}
-    <h1 class="govuk-heading-l">{{ i18n.needToBeAddedToAuthorisedAgentAccountHeading }}</h1>
-    <p class="govuk-body">{{ i18n.needToAskToBeAdded }}</p>
+    <h1 class="govuk-heading-l">
+        {{ i18n.needToBeAnAcspHeading }}
+    </h1>
+
     <p class="govuk-body">
-        {{ i18n.applyAsAnAuthorisedAgent }}
-        <a href={{ applyAsACSPLink }}>{{ i18n.applyAsAnAuthorisedAgentLink }}</a>.
+        {{ i18n.acspNotLinkedToEmail }}
+    </p>
+
+    <p class="govuk-body">
+        {{ i18n.onlyAcspsCanFile }}
+    </p>
+
+    <p class="govuk-body">
+        {{ i18n.acspDefinition }}
+    </p>
+
+    <h2 class="govuk-heading-m">
+        {{ i18n.workForRegisteredAcspHeading }}
+    </h2>
+
+    <p class="govuk-body">
+        {{ i18n.askBusinessToAddYou }}
+        {{ i18n.findOutMoreReadSection }}
+        <a href="https://www.gov.uk/guidance/being-an-authorised-corporate-service-provider#how-to-use-your-authorised-agent-account" class="govuk-link">
+            {{ i18n.guidanceBeingAnAcspLinkText }}
+        </a>.
+    </p>
+
+    <h2 class="govuk-heading-m">
+        {{ i18n.needToRegisterAsAcspHeading }}
+    </h2>
+
+    <p class="govuk-body">
+        <a href="https://www.gov.uk/guidance/applying-to-register-as-a-companies-house-authorised-agent" class="govuk-link">
+            {{ i18n.guidanceRegisteringAsAcspLinkText }}
+        </a>
+    </p>
+
+    <h2 class="govuk-heading-m">
+        {{ i18n.someoneElseInvolvedHeading }}
+    </h2>
+
+    <p class="govuk-body">
+        {{ i18n.needToFindAnAcsp }}
+        <a href="https://www.gov.uk/government/publications/list-of-authorised-corporate-service-providers-acsps" class="govuk-link">
+            {{ i18n.findAnAcspLinkText }}
+        </a>
+        {{ i18n.toFileOnYourBehalf }}
     </p>
 {% endblock content %}


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/CSE-1329

This pull request updates the messaging and content for the "must be authorised agent" page to reflect new requirements around Authorised Corporate Service Providers (ACSPs), replacing the previous "authorised agent" terminology. The changes introduce clearer guidance for users about ACSP requirements, registration, and what to do if they are not an ACSP, with updates in both English and Welsh language files and the corresponding view template.

**Content and Messaging Updates:**

* Replaced all references to "authorised agent" with "Authorised Corporate Service Provider (ACSP)" in both English (`locales/en/must-be-authorised-agent.json`) and Welsh (`locales/cy/must-be-authorised-agent.json`) translation files, updating headings, descriptions, and guidance links. [[1]](diffhunk://#diff-8a41a25e941b47e91b27ebdc53e6f4605ecf319c813275fc7735b968b4d9f0e6L2-R15) [[2]](diffhunk://#diff-f02b6aca167d4c26e4c35392665ebb758d6195c01651e7aff8e8c8f9ab5d1e9cL2-R15)
* Added new guidance messages and sections to explain what an ACSP is, how to register as one, what to do if your email is not linked to an ACSP account, and how others can find an ACSP to file on their behalf. [[1]](diffhunk://#diff-8a41a25e941b47e91b27ebdc53e6f4605ecf319c813275fc7735b968b4d9f0e6L2-R15) [[2]](diffhunk://#diff-f02b6aca167d4c26e4c35392665ebb758d6195c01651e7aff8e8c8f9ab5d1e9cL2-R15)

**View Template Update:**

* Updated the `must-be-authorised-agent.njk` template to use the new ACSP-related messages and structure, including new sections for registration, guidance, and finding an ACSP, as well as updated links to relevant GOV.UK guidance pages.