### PR TITLE
CSE-996 CS Date Validation Early Filing

### DIFF
--- a/locales/en/confirmation-statement-date.json
+++ b/locales/en/confirmation-statement-date.json
@@ -18,6 +18,7 @@
   "CDSErrorDateNoYear":"Confirmation statement date must include a year",
   "CDSErrorDateWrong":"Confirmation statement date must be a real date",
   "CDSErrorPastDate":"The date you enter must be on or before ",
+  "CDSErrorEarlyPastDate":"Confirmation statement date must be today or in the past",
   "CDSErrorSameCsDate":"A confirmation statement has already been filed for the date you’ve entered",
   "CDSErrorCsDateAfterlastCsDate":"The date you enter must be after the date of the last confirmation statement",
   "CDSDateValueInvalidError":"Error: The confirmation statement date is invalid",

--- a/src/validators/lp.cs.date.validator.ts
+++ b/src/validators/lp.cs.date.validator.ts
@@ -86,15 +86,17 @@ export function getCsDateInput(date: CsDateValue): Date {
 
 function validateFutureDate(csDateInput: Date, company: CompanyProfile, localInfo: any): string | undefined {
     if (moment(csDateInput).isAfter(moment().startOf("day"))) {
-        let expectedCSDate: string | undefined;
+        let errorMessage: string | undefined;
 
-        if (company.confirmationStatement?.lastMadeUpTo) {
-            expectedCSDate = formatDateString("DD/MM/YYYY", company.confirmationStatement?.nextMadeUpTo);
+        if (isTodayBeforeFileCsDate(company)) {
+            return localInfo.i18n.CDSErrorEarlyPastDate;
         }
 
-        const errorMessage = localInfo.i18n.CDSErrorPastDate + expectedCSDate;
+        const expectedCSDate = company.confirmationStatement?.lastMadeUpTo
+            ? formatDateString("DD/MM/YYYY", company.confirmationStatement.nextMadeUpTo)
+            : "";
 
-        return errorMessage;
+        return localInfo.i18n.CDSErrorPastDate + expectedCSDate;
     }
     return undefined;
 }

--- a/test/validators/lp.cs.date.validator.unit.ts
+++ b/test/validators/lp.cs.date.validator.unit.ts
@@ -98,7 +98,7 @@ describe("LP CS date validator tests", () => {
         );
     });
 
-    it("validateDateSelectorValue should return CDSErrorPastDate error message if the CS date is in the future", () => {
+    it("validateDateSelectorValue should return CDSErrorEarlyPastDate error message if the CS date is in the future and filing is early", () => {
         const csDateValue: CsDateValue = {
             csDateYear: "2099",
             csDateMonth: "12",
@@ -112,13 +112,32 @@ describe("LP CS date validator tests", () => {
             overdue: false,
         };
 
-        const csExpectedDate = formatDateString(
+        expect(validateDateSelectorValue(localInfo, csDateValue, validLimitedPartnershipProfile)).toEqual(
+            localInfo.i18n.CDSErrorEarlyPastDate
+        );
+    });
+
+    it("validateDateSelectorValue should return CDSErrorPastDate when the CS date is in the future and filing is due", () => {
+        const csDateValue: CsDateValue = {
+            csDateYear: "2099",
+            csDateMonth: "12",
+            csDateDay: "31",
+        };
+
+        validLimitedPartnershipProfile.confirmationStatement = {
+            lastMadeUpTo: "2020-03-15",
+            nextMadeUpTo: "2021-03-15", // In the past so isTodayBeforeFileCsDate() is false
+            nextDue: "2099-03-29",
+            overdue: true,
+        };
+
+        const expectedCsDate = formatDateString(
             "DD/MM/YYYY",
-            validLimitedPartnershipProfile.confirmationStatement?.nextMadeUpTo
+            validLimitedPartnershipProfile.confirmationStatement.nextMadeUpTo
         );
 
         expect(validateDateSelectorValue(localInfo, csDateValue, validLimitedPartnershipProfile)).toEqual(
-            localInfo.i18n.CDSErrorPastDate + csExpectedDate
+            localInfo.i18n.CDSErrorPastDate + expectedCsDate
         );
     });
 


### PR DESCRIPTION
Updating the logic to show the correct validation message when trying to file a confirmation statement early with incorrect date.