### PR TITLE
CSE-1329 : Fixing back button bug 

### DIFF
--- a/src/controllers/lp.must.be.authorised.agent.controller.ts
+++ b/src/controllers/lp.must.be.authorised.agent.controller.ts
@@ -1,14 +1,19 @@
 import { Request, Response } from "express";
 import { Templates } from "../types/template.paths";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
+import { urlUtils } from "../utils/url";
+import * as urls from "../types/page.urls";
 
 export const get = (req: Request, res: Response) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
 
+    let prevPageURL = `${urls.CONFIRM_COMPANY_PATH}?companyNumber=${urlUtils.getCompanyNumberFromRequestParams(req)}`;
+
     return res.render(Templates.LP_MUST_BE_AUTHORISED_AGENT, {
         ...getLocaleInfo(locales, lang),
         htmlLang: lang,
+        previousPageWithoutLang: prevPageURL,
         applyAsACSPLink: addLangToUrl("/register-as-companies-house-authorised-agent", lang),
     });
 };

--- a/src/types/template.paths.ts
+++ b/src/types/template.paths.ts
@@ -44,5 +44,5 @@ export enum Templates {
     LP_SIC_CODE_SUMMARY = "limited-partners/components/sic-code-summary/sic-code-summary.njk",
     LP_MUST_BE_AUTHORISED_AGENT = "limited-partners/components/must-be-authorised-agent/must-be-authorised-agent.njk",
     LP_STOP_SCREEN = "limited-partners/components/stop-screen/stop-screen.njk",
-    LP_TRANSITIONAL_STOP_SCREEN = "limited-partners/components/stop-screen/transitional-stop-screen.njk"
+    LP_TRANSITIONAL_STOP_SCREEN = "limited-partners/components/stop-screen/transitional-stop-screen.njk",
 }


### PR DESCRIPTION
This pull request updates the `lp.must.be.authorised.agent` controller to improve navigation and localization support for the "must be authorised agent" page. The main change is the addition of a `previousPageWithoutLang` URL to the template context, ensuring users can navigate back to the correct page without language parameters. There is also a minor update to the `Templates` enum formatting.

**Controller improvements:**

* Added construction of a `prevPageURL` (without language parameter) using `urls.CONFIRM_COMPANY_PATH` and the company number extracted from the request, and passed this as `previousPageWithoutLang` to the template context in `lp.must.be.authorised.agent.controller.ts`.

**Code quality/formatting:**

* Added a trailing comma to the `Templates` enum in `template.paths.ts` for consistency.