### PR TITLE
CSE-1329: Company Number picked up by URL 

### DIFF
--- a/src/controllers/lp.must.be.authorised.agent.controller.ts
+++ b/src/controllers/lp.must.be.authorised.agent.controller.ts
@@ -1,14 +1,17 @@
 import { Request, Response } from "express";
 import { Templates } from "../types/template.paths";
 import { addLangToUrl, getLocaleInfo, getLocalesService, selectLang } from "../utils/localise";
-import { urlUtils } from "../utils/url";
 import * as urls from "../types/page.urls";
+import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
+import { getCompanyProfileFromSession } from "../utils/session";
 
 export const get = (req: Request, res: Response) => {
     const lang = selectLang(req.query.lang);
     const locales = getLocalesService();
 
-    let prevPageURL = `${urls.CONFIRM_COMPANY_PATH}?companyNumber=${urlUtils.getCompanyNumberFromRequestParams(req)}`;
+    const company: CompanyProfile = getCompanyProfileFromSession(req);
+
+    let prevPageURL = `${urls.CONFIRM_COMPANY_PATH}?companyNumber=${company.companyNumber}`;
 
     return res.render(Templates.LP_MUST_BE_AUTHORISED_AGENT, {
         ...getLocaleInfo(locales, lang),

--- a/test/controllers/lp.must.be.authorised.agent.controller.ts
+++ b/test/controllers/lp.must.be.authorised.agent.controller.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import app from "../../src/app";
 import middlewareMocks from "../mocks/all.middleware.mock";
-import { LP_MUST_BE_AUTHORISED_AGENT_PATH } from "../../src/types/page.urls";
+import { LP_MUST_BE_AUTHORISED_AGENT_PATH, CONFIRM_COMPANY_PATH } from "../../src/types/page.urls";
 
 describe("must be authorised agent controller tests", () => {
     beforeEach(() => {
@@ -14,5 +14,30 @@ describe("must be authorised agent controller tests", () => {
         expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalled();
         expect(response.status).toBe(200);
         expect(response.text).toContain("You need to be added to an authorised agent account to view this page");
+    });
+
+    it("should back-link to confirm company with companyNumber query when provided", async () => {
+        const COMPANY_NUMBER = "12345678";
+        const response = await request(app).get(
+            `${LP_MUST_BE_AUTHORISED_AGENT_PATH}?lang=en&companyNumber=${COMPANY_NUMBER}`
+        );
+
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(response.status).toBe(200);
+
+        const regex = new RegExp(
+            '<a href="' + CONFIRM_COMPANY_PATH + "\\?companyNumber=" + COMPANY_NUMBER + '" class="govuk-back-link'
+        );
+        expect(response.text).toMatch(regex);
+    });
+
+    it("should back-link to confirm company without companyNumber when not provided", async () => {
+        const response = await request(app).get(`${LP_MUST_BE_AUTHORISED_AGENT_PATH}?lang=en`);
+
+        expect(middlewareMocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        expect(response.status).toBe(200);
+
+        const regex = new RegExp('<a href="' + CONFIRM_COMPANY_PATH + '" class="govuk-back-link');
+        expect(response.text).toMatch(regex);
     });
 });


### PR DESCRIPTION
This pull request updates the logic for generating the back-link URL on the "Must Be Authorised Agent" page and adds tests to ensure correct behavior. The main changes are focused on improving how the company number is handled in the back-link and increasing test coverage for this logic.

**Back-link URL logic improvement:**

* Refactored the controller (`lp.must.be.authorised.agent.controller.ts`) to retrieve the company number from the session's company profile instead of directly from request parameters, ensuring more reliable and consistent data access.

**Testing enhancements:**

* Added tests to verify that the back-link on the page correctly includes the `companyNumber` query parameter when provided, and omits it when not provided. This ensures the UI behaves as expected in both scenarios.
* Updated test imports to include the necessary page URLs for the new tests.