### PR TITLE
CSE-1416: Separate URLs for each ENV

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,16 @@ nunjucksEnv.addGlobal("govukFrontendVersion", getGOVUKFrontendVersion());
 nunjucksEnv.addGlobal("PIWIK_URL", process.env.PIWIK_URL);
 nunjucksEnv.addGlobal("PIWIK_SITE_ID", process.env.PIWIK_SITE_ID);
 nunjucksEnv.addGlobal("CONTACT_US_URL", process.env.CONTACT_US_URL);
+nunjucksEnv.addGlobal(
+    "COMPANY_INFORMATION_BASE_URL",
+    process.env.COMPANY_INFORMATION_BASE_URL ||
+        ((): string => {
+            const env = process.env.NODE_ENV;
+            if (env === "staging") return "https://staging.company-information.service.gov.uk";
+            if (env === "cidev") return "https://cidev.aws.chdev.org";
+            return "https://find-and-update.company-information.service.gov.uk";
+        })()
+);
 nunjucksEnv.addGlobal("govukRebrand", true);
 
 // Required because it is used on error pages that might occur at any point during the user journey.

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,7 @@ nunjucksEnv.addGlobal("PIWIK_SITE_ID", process.env.PIWIK_SITE_ID);
 nunjucksEnv.addGlobal("CONTACT_US_URL", process.env.CONTACT_US_URL);
 nunjucksEnv.addGlobal(
     "COMPANY_INFORMATION_BASE_URL",
-    process.env.COMPANY_INFORMATION_BASE_URL ||
+    process.env.COMPANY_INFORMATION_BASE_URL ??
         ((): string => {
             const env = process.env.NODE_ENV;
             if (env === "staging") return "https://staging.company-information.service.gov.uk";

--- a/views/limited-partners/components/before-you-file/before-you-file.njk
+++ b/views/limited-partners/components/before-you-file/before-you-file.njk
@@ -63,7 +63,7 @@
                 <p class="govuk-body">
                     {{i18n.BYFFileUpdatesParagraphStart}}
                     {% if company.companyNumber %}
-                        <a href="https://find-and-update.company-information.service.gov.uk/company/{{company.companyNumber}}" target="_blank"
+                        <a href="{{COMPANY_INFORMATION_BASE_URL}}/company/{{company.companyNumber}}" target="_blank"
                         data-event-id="check-company-info-link">
                             {{i18n.BYFFileUpdatesParagraphLink}}
                         </a>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/CSE-1416

This pull request updates how the base URL for company information is determined and used throughout the application. The main change is centralizing the logic for the company information service URL, making it configurable via environment variables and dynamic based on the deployment environment, which improves maintainability and flexibility.

**Configuration improvements:**

* Added a new global variable `COMPANY_INFORMATION_BASE_URL` to the Nunjucks environment in `src/app.ts`. This variable is set from the `COMPANY_INFORMATION_BASE_URL` environment variable if present, or falls back to a default value based on `NODE_ENV` (`staging`, `cidev`, or production).

**Template updates:**

* Updated the company information link in `before-you-file.njk` to use the new `COMPANY_INFORMATION_BASE_URL` global variable instead of a hardcoded URL, ensuring the correct base URL is used in different environments.