### PR TITLE
CSE-1416 : Company information link on BYF screen

### DIFF
--- a/src/controllers/lp.before.you.file.controller.ts
+++ b/src/controllers/lp.before.you.file.controller.ts
@@ -5,7 +5,7 @@ import * as urls from "../types/page.urls";
 import { CompanyProfile } from "@companieshouse/api-sdk-node/dist/services/company-profile/types";
 import { Session } from "@companieshouse/node-session-handler";
 import { getAcspSessionData, resetAcspSession, updateAcspSessionData } from "../utils/session.acsp";
-import { CS01_COST } from "../utils/properties";
+import { CS01_COST, COMPANY_INFO_URL } from "../utils/properties";
 import { urlUtils } from "../utils/url";
 import { getCompanyProfileFromSession } from "../utils/session";
 import { isPaymentDue } from "../utils/payments";
@@ -51,6 +51,7 @@ export const get = async (req: Request, res: Response, next: NextFunction) => {
             urls,
             company,
             CS01_COST,
+            COMPANY_INFO_URL,
             previousPageWithoutLang: prevPageURL,
             formData,
             showSICCodeReference: showSICCodeReference(company),
@@ -104,6 +105,7 @@ function reloadPageWithError(req: Request, res: Response, options: ReloadPageOpt
         company: company,
         urls,
         CS01_COST,
+        COMPANY_INFO_URL,
         previousPage: urls.ACSP_LIMITED_PARTNERSHIP,
         isPaymentDue: isPaymentDue,
         pageProperties: {

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -96,4 +96,7 @@ export const SKIP_START_PAGE_COMPANY_TYPES = getEnvironmentVariable(
     "limited-partnership"
 );
 
-export const COMPANY_INFO_URL = getEnvironmentVariable("COMPANY_INFO_URL");
+export const COMPANY_INFO_URL = getEnvironmentVariable(
+    "COMPANY_INFO_URL",
+    "https://find-and-update.company-information.service.gov.uk"
+);

--- a/src/utils/properties.ts
+++ b/src/utils/properties.ts
@@ -95,3 +95,5 @@ export const SKIP_START_PAGE_COMPANY_TYPES = getEnvironmentVariable(
     "SKIP_START_PAGE_COMPANY_TYPES",
     "limited-partnership"
 );
+
+export const COMPANY_INFO_URL = getEnvironmentVariable("COMPANY_INFO_URL");

--- a/test/global.setup.ts
+++ b/test/global.setup.ts
@@ -23,4 +23,5 @@ export default () => {
     process.env.EWF_URL = "https://ewf.companieshouse.gov.uk/";
     process.env.CS01_COST = "50";
     process.env.CS01_PAPER_FEE = "110";
+    process.env.COMPANY_INFO_URL = "https://find-and-update.company-information.service.gov.uk";
 };

--- a/views/limited-partners/components/before-you-file/before-you-file.njk
+++ b/views/limited-partners/components/before-you-file/before-you-file.njk
@@ -63,7 +63,7 @@
                 <p class="govuk-body">
                     {{i18n.BYFFileUpdatesParagraphStart}}
                     {% if company.companyNumber %}
-                        <a href="https://find-and-update.company-information.service.gov.uk/company/{{company.companyNumber}}" target="_blank"
+                        <a href="{{COMPANY_INFO_URL}}/company/{{company.companyNumber}}" target="_blank"
                         data-event-id="check-company-info-link">
                             {{i18n.BYFFileUpdatesParagraphLink}}
                         </a>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/CSE-1416 

This pull request introduces support for a configurable company information URL, replacing the previously hardcoded link in the "Before You File" page. The URL is now sourced from an environment variable and passed through the backend to the frontend template, improving flexibility and maintainability.

**Configuration and URL Handling:**

* Added `COMPANY_INFO_URL` to `src/utils/properties.ts`, sourcing it from an environment variable for easier configuration.
* Updated the controller (`src/controllers/lp.before.you.file.controller.ts`) to import and pass `COMPANY_INFO_URL` to both the main page and error reload rendering contexts. [[1]](diffhunk://#diff-479e085683c6ae2b50a95397b3d940f03e1ee924ed9bc84c4df480e8d292ed12L8-R8) [[2]](diffhunk://#diff-479e085683c6ae2b50a95397b3d940f03e1ee924ed9bc84c4df480e8d292ed12R54) [[3]](diffhunk://#diff-479e085683c6ae2b50a95397b3d940f03e1ee924ed9bc84c4df480e8d292ed12R108)

**Template Update:**

* Modified `views/limited-partners/components/before-you-file/before-you-file.njk` to use the configurable `COMPANY_INFO_URL` instead of a hardcoded URL for company information links.