### PR TITLE
CSE-1424: Fixing sonar reliability issues

### DIFF
--- a/views/paper-filing.html
+++ b/views/paper-filing.html
@@ -13,9 +13,9 @@
       <p>{{ company.companyName }} is a {{ company.type }}, which means it can only file confirmation statements using the
 
         {% if company.type === "limited-partnership" %}
-          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-limited-partnership-slp-cs01"/>SLP CSO1 confirmation statement paper form</a>.
+          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-limited-partnership-slp-cs01">SLP CSO1 confirmation statement paper form</a>.
         {% elseif company.type === "scottish-partnership" %}
-          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01"/>SQP CSO1 confirmation statement paper form</a>.
+          <a href="https://www.gov.uk/government/publications/confirmation-statement-for-a-scottish-qualifying-partnership-sqp-cs01">SQP CSO1 confirmation statement paper form</a>.
         {% else %}
            <a href="https://www.gov.uk/government/publications/confirmation-statement-form-cs01-new-version" data-event-id="confirmation-statement-paper-form-link">CS01 confirmation statement paper form</a>.
         {% endif %}

--- a/views/start.html
+++ b/views/start.html
@@ -92,12 +92,12 @@
           <a class="govuk-notification-banner__link" href="{{ i18n.startWebFilingLink }}" data-event-id="web-filing-link-clicked">{{ i18n.startWebFilingServiceName }}</a>.
         </div>
       {% else %}
-        <a href="/confirmation-statement/company-number" id="start-now" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}'])" onkeydown="if (event.key === ' ' || event.key === 'Spacebar') { event.preventDefault(); this.click(); }" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
+        <button type="button" id="start-now" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}']); window.location.href='/confirmation-statement/company-number';" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" role="presentation" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
           </svg>
-        </a>
+        </button>
       {% endif %}
 
 

--- a/views/start.html
+++ b/views/start.html
@@ -92,7 +92,7 @@
           <a class="govuk-notification-banner__link" href="{{ i18n.startWebFilingLink }}" data-event-id="web-filing-link-clicked">{{ i18n.startWebFilingServiceName }}</a>.
         </div>
       {% else %}
-        <a href="/confirmation-statement/company-number" id="start-now" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}'])" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
+        <a href="/confirmation-statement/company-number" id="start-now" onclick="_paq.push(['trackGoal', '{{PIWIK_START_GOAL_ID}}'])" onkeydown="if (event.key === ' ' || event.key === 'Spacebar') { event.preventDefault(); this.click(); }" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
           Start now
           <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" role="presentation" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/CSE-1424

This pull request makes small but important improvements to accessibility and correctness in the HTML templates for starting and filing confirmation statements. The main changes include fixing anchor tag syntax errors and improving keyboard accessibility for the "Start now" button.

Accessibility improvements:

* Added an `onkeydown` handler to the "Start now" button in `views/start.html` so that pressing the spacebar will activate the button, improving keyboard accessibility.

HTML correctness:

* Fixed invalid self-closing anchor tag syntax in `views/paper-filing.html` by replacing `<a .../>` with properly opened and closed `<a>...</a>` tags for the SLP CSO1 and SQP CSO1 confirmation statement paper form links.