### PR TITLE
Update limited.partnership.confirmation.ts

### DIFF
--- a/src/utils/confirmation/limited.partnership.confirmation.ts
+++ b/src/utils/confirmation/limited.partnership.confirmation.ts
@@ -101,6 +101,8 @@ export async function sendLimitedPartnershipTransactionUpdate(
 
     if (newCsDate && isValidDate(newCsDate)) {
         currentCsSubmission.data.newConfirmationDate = newCsDate;
+    } else if (newCsDate === null) {
+        currentCsSubmission.data.newConfirmationDate = undefined;
     }
     currentCsSubmission.data.sicCodeData = newSicCodes ?? undefined;
 

--- a/test/utils/limited.partnership.unit.ts
+++ b/test/utils/limited.partnership.unit.ts
@@ -236,6 +236,21 @@ describe("Limited partnership util tests", () => {
         expect(mockConfirmationStatementSubmission.data.newConfirmationDate).toContain("2025-09-01");
     });
 
+    it("sendLimitedPartnershipTransactionUpdate should clear newConfirmationDate when null is passed (on-time/late No selection)", async () => {
+        const req = {
+            session: sessionData,
+            params: { companyNumber: "258258", transactionId: "123456", submissionId: "654321" } as ParamsDictionary,
+        } as Request;
+        const submissionWithPreviousDate = {
+            ...mockConfirmationStatementSubmission,
+            data: { ...mockConfirmationStatementSubmission.data, newConfirmationDate: "2025-09-01" },
+        };
+        mockGetConfirmationStatement.mockResolvedValue(submissionWithPreviousDate);
+
+        await sendLimitedPartnershipTransactionUpdate(req, null, null);
+        expect(submissionWithPreviousDate.data.newConfirmationDate).toBeUndefined();
+    });
+
     it("isIntegratedJourney returns false if session does not have gci_return_url", () => {
         let response: boolean = limitedPartnershipUtil.isIntegratedJourney(sessionData);
         expect(response).toBeFalsy();


### PR DESCRIPTION
Adding a null check to newCsDate to handle a "No" radio selection each time.

To correct this behaviour seen: 
Select Yes - enter a date and continue
Go back Select No - complete the submission
Todays date that is used for the No selection is not stored in chips or mongo-db the previous yes selection 

https://companieshouse.slack.com/files/U08EW1Z0AQY/F0BLFTRH59R/screen_recording_2026-07-29_at_16.02.36.mov