### PR TITLE
Update companyNumber

### DIFF
--- a/test/controllers/lp.stop.screen.controller.unit.ts
+++ b/test/controllers/lp.stop.screen.controller.unit.ts
@@ -26,6 +26,13 @@ describe("LP stop screen controller tests", () => {
         expect(response.text).toContain(validLimitedPartnershipProfile.companyName);
     });
 
+    it("Should use companyNumber in back link, not the current company number", async () => {
+        const response = await request(app).get(LP_STOP_SCREEN_PATH);
+
+        expect(response.text).toContain("companyNumber={companyNumber}");
+        expect(response.text).not.toContain(`companyNumber=${validLimitedPartnershipProfile.companyNumber}`);
+    });
+
     it("Should return error page if no company in session", async () => {
         mockGetCompanyProfileFromSession.mockReturnValueOnce(undefined);
         const response = await request(app).get(LP_STOP_SCREEN_PATH);

--- a/views/limited-partners/components/stop-screen/stop-screen.njk
+++ b/views/limited-partners/components/stop-screen/stop-screen.njk
@@ -14,7 +14,7 @@
                 </h1>
                 <p>A confirmation statement cannot be filed for {{ company.companyName }} because it has been closed.</p>
                 <p><a data-event-id="contact-information-wrong" href="https://www.gov.uk/government/organisations/companies-house/about/access-and-opening">Contact us</a> if you think this information is wrong.</p>
-                <p>If this is the wrong limited partnership, <a data-event-id="start-again" href="/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber={{company.companyNumber}}&backLink=/confirmation-statement/">go back and enter a different company number</a>.</p>
+                <p>If this is the wrong limited partnership, <a data-event-id="start-again" href="/company-lookup/search?forward=/confirmation-statement/confirm-company?companyNumber={companyNumber}&backLink=/confirmation-statement/">go back and enter a different company number</a>.</p>
                 <p>
                     <a href="https://www.smartsurvey.co.uk/s/fileconfstmnt-cannotfiledissolvedorliquidated/">What did you think of this service?</a>
                     (takes 2 minutes)


### PR DESCRIPTION
The stop screen is using the variable for company number, rendering the old company number into the URL, so the lookup always redirects back with the stale number. Updated to use the newly entered variable.

https://companieshouse.atlassian.net/browse/CSE-1374